### PR TITLE
Refactor: use namespacing in JS and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,3 +393,38 @@ $notice = AdminNotices::show('my_notice', 'This is a notice')
 $notice = AdminNotices::show('my_notice', 'This is a notice')
     ->notDismissible();
 ```
+
+## Resetting dismissed notices
+
+For dismissible notices, when the user dismisses the notice, it is permanently dismissed. If you
+want
+to reset the dismissed notice(s), there are a couple methods available.
+
+### `resetNoticeForUser($notificationId, $userId)`
+
+Reset a specific notification for a user.
+
+Parameters:
+
+1. `string $notificationId` - The unique identifier for the notice
+2. `int $userId` - The user ID to reset the notice for
+
+```php
+use StellarWP\AdminNotices\AdminNotices;
+
+AdminNotices::resetNoticeForUser('my_notice', get_current_user_id());
+```
+
+### `resetAllNoticesForUser($userId)`
+
+Reset all dismissed notices for a user.
+
+Parameters:
+
+1. `int $userId` - The user ID to reset all notices for
+
+```php
+use StellarWP\AdminNotices\AdminNotices;
+
+AdminNotices::resetAllNoticesForUser(get_current_user_id());
+```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "stellarwp/admin-notices",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "A handy package for easily displaying admin notices in WordPress with simple to complex visibility conditions",
     "minimum-stability": "stable",
     "license": "MIT",

--- a/src/Actions/DisplayNoticesInAdmin.php
+++ b/src/Actions/DisplayNoticesInAdmin.php
@@ -167,7 +167,7 @@ class DisplayNoticesInAdmin
     {
         $userPreferences = get_user_meta(get_current_user_id(), 'wp_persisted_preferences', true);
 
-        $key = "stellarwp/$this->namespace/admin-notices";
+        $key = "stellarwp/admin-notices/$this->namespace";
         if (!is_array($userPreferences) || empty($userPreferences[$key])) {
             return true;
         }

--- a/src/Actions/DisplayNoticesInAdmin.php
+++ b/src/Actions/DisplayNoticesInAdmin.php
@@ -8,15 +8,20 @@ namespace StellarWP\AdminNotices\Actions;
 use DateTimeImmutable;
 use DateTimeZone;
 use StellarWP\AdminNotices\AdminNotice;
+use StellarWP\AdminNotices\Traits\HasNamespace;
 
 /**
  * Displays the provided notices in the admin based on the conditions set in the notice.
  *
+ * @since 1.1.0 added namespacing
  * @since 1.0.0
  */
 class DisplayNoticesInAdmin
 {
+    use HasNamespace;
+
     /**
+     * @since 1.1.0 passed the namespace to RenderAdminNotice
      * @since 1.0.0
      */
     public function __invoke(AdminNotice ...$notices)
@@ -27,7 +32,7 @@ class DisplayNoticesInAdmin
 
         foreach ($notices as $notice) {
             if ($this->shouldDisplayNotice($notice)) {
-                echo (new RenderAdminNotice($notice))();
+                echo (new RenderAdminNotice($this->namespace))($notice);
             }
         }
     }
@@ -152,11 +157,17 @@ class DisplayNoticesInAdmin
         return false;
     }
 
+    /**
+     * Checks whether the notice has been dismissed by the user.
+     *
+     * @since 1.1.0 added namespacing to the preferences key
+     * @since 1.0.0
+     */
     private function passesDismissedConditions(AdminNotice $notice): bool
     {
         $userPreferences = get_user_meta(get_current_user_id(), 'wp_persisted_preferences', true);
 
-        $key = "stellarwp/admin-notices";
+        $key = "stellarwp/$this->namespace/admin-notices";
         if (!is_array($userPreferences) || empty($userPreferences[$key])) {
             return true;
         }

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -6,55 +6,55 @@ declare(strict_types=1);
 namespace StellarWP\AdminNotices\Actions;
 
 use StellarWP\AdminNotices\AdminNotice;
+use StellarWP\AdminNotices\Traits\HasNamespace;
 
 /**
  * Renders the admin notice based on the configuration of the notice.
  *
+ * @since 1.1.0 refactored to use namespace and notice is passed to the __invoke method
  * @since 1.0.0
  */
 class RenderAdminNotice
 {
+    use HasNamespace;
+
     /**
      * @var AdminNotice
      */
     private $notice;
 
-    public function __construct(AdminNotice $notice)
-    {
-        $this->notice = $notice;
-    }
-
     /**
      * Renders the admin notice
      *
-     * @since 1.1.0 changed data-notice-id to data-stellarwp-notice-id to avoid conflicts with other plugins
+     * @since 1.1.0 added namespacing and notice is passed to the __invoke method
      * @since 1.0.0
      */
-    public function __invoke(): string
+    public function __invoke(AdminNotice $notice): string
     {
-        if (!$this->notice->usesWrapper()) {
-            return $this->notice->getRenderedContent();
+        if (!$notice->usesWrapper()) {
+            return $notice->getRenderedContent();
         }
 
         return sprintf(
-            "<div class='%s' data-stellarwp-notice-id='%s'>%s</div>",
-            esc_attr($this->getWrapperClasses()),
-            $this->notice->getId(),
-            $this->notice->getRenderedContent()
+            "<div class='%s' data-stellarwp-$this->namespace-notice-id='%s'>%s</div>",
+            esc_attr($this->getWrapperClasses($notice)),
+            $notice->getId(),
+            $notice->getRenderedContent()
         );
     }
 
     /**
      * Generates the classes for the standard WordPress notice wrapper.
      *
+     * @since 1.1.0 notice is passed instead of accessed as a property
      * @since 1.0.0
      */
-    private function getWrapperClasses(): string
+    private function getWrapperClasses(AdminNotice $notice): string
     {
-        $classes = ['notice', 'notice-' . $this->notice->getUrgency()];
+        $classes = ['notice', 'notice-' . $notice->getUrgency()];
 
-        if ($this->notice->isDismissible()) {
-            $classes[] = 'is-dismissible';
+        if ($notice->isDismissible()) {
+            $classes[] = "is-dismissible";
         }
 
         return implode(' ', $classes);

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -24,6 +24,12 @@ class RenderAdminNotice
         $this->notice = $notice;
     }
 
+    /**
+     * Renders the admin notice
+     *
+     * @since 1.1.0 changed data-notice-id to data-stellarwp-notice-id to avoid conflicts with other plugins
+     * @since 1.0.0
+     */
     public function __invoke(): string
     {
         if (!$this->notice->usesWrapper()) {
@@ -31,7 +37,7 @@ class RenderAdminNotice
         }
 
         return sprintf(
-            "<div class='%s' data-notice-id='%s'>%s</div>",
+            "<div class='%s' data-stellarwp-notice-id='%s'>%s</div>",
             esc_attr($this->getWrapperClasses()),
             $this->notice->getId(),
             $this->notice->getRenderedContent()

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -19,11 +19,6 @@ class RenderAdminNotice
     use HasNamespace;
 
     /**
-     * @var AdminNotice
-     */
-    private $notice;
-
-    /**
      * Renders the admin notice
      *
      * @since 1.1.0 added namespacing and notice is passed to the __invoke method

--- a/src/AdminNotices.php
+++ b/src/AdminNotices.php
@@ -35,12 +35,13 @@ class AdminNotices
      * Registers a notice to be conditionally displayed in the admin
      *
      * @since 1.0.0
+     * @since 1.1.0 no longer include namespace in AdminNotice id
      *
      * @param string|callable $render
      */
     public static function show(string $notificationId, $render): AdminNotice
     {
-        $notice = new AdminNotice(self::$namespace . '/' . $notificationId, $render);
+        $notice = new AdminNotice($notificationId, $render);
 
         self::getRegistrar()->registerNotice($notice);
 
@@ -150,11 +151,10 @@ class AdminNotices
 
         $preferencesKey = $wpdb->get_blog_prefix() . 'persisted_preferences';
         $preferences = get_user_meta($userId, $preferencesKey, true);
-        $packageKey = 'stellarwp/' . self::$namespace . '/admin-notices';
+        $packageKey = 'stellarwp/admin-notices/' . self::$namespace;
 
-        $notificationKey = self::$namespace . '/' . $notificationId;
-        if (isset($preferences[$packageKey][$notificationKey])) {
-            unset($preferences[$packageKey][$notificationKey]);
+        if (isset($preferences[$packageKey][$notificationId])) {
+            unset($preferences[$packageKey][$notificationId]);
             update_user_meta($userId, $preferencesKey, $preferences);
         }
     }
@@ -171,7 +171,7 @@ class AdminNotices
 
         $preferencesKey = $wpdb->get_blog_prefix() . 'persisted_preferences';
         $preferences = get_user_meta($userId, $preferencesKey, true);
-        $packageKey = 'stellarwp/' . self::$namespace . '/admin-notices';
+        $packageKey = 'stellarwp/admin-notices/' . self::$namespace;
 
         if (isset($preferences[$packageKey])) {
             unset($preferences[$packageKey]);

--- a/src/AdminNotices.php
+++ b/src/AdminNotices.php
@@ -193,6 +193,7 @@ class AdminNotices
     /**
      * Hook action to enqueue the scripts needed for dismissing notices
      *
+     * @since 1.1.0 added the namespacing attribute to the script tag
      * @since 1.0.2 use filetime for versioning, which will bust the cache when the library is updated
      * @since 1.0.0
      */

--- a/src/Traits/HasNamespace.php
+++ b/src/Traits/HasNamespace.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\AdminNotices\Traits;
+
+trait HasNamespace
+{
+    /**
+     * The namespace for the plugin.
+     *
+     * @var string
+     */
+    protected $namespace;
+
+    public function __construct(string $namespace)
+    {
+        $this->namespace = $namespace;
+    }
+}

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -1,30 +1,36 @@
-window.stellarwp = window.stellarwp || {};
-window.stellarwp.adminNotices = {
-    /**
-     * Dismisses a notice with the given ID.
-     *
-     * @since 1.1.0
-     *
-     * @param {string} noticeId
-     */
-    dismissNotice: function (noticeId) {
-        const now = Math.floor(Date.now() / 1000);
-        wp.data.dispatch('core/preferences').set('stellarwp/admin-notices', noticeId, now);
-    },
-};
+(function ($, dispatch, document) {
+    // Set up the package functions using the namespace provided by the script tag.
+    const currentScript = typeof document.currentScript !== 'undefined' ? document.currentScript : document.scripts[document.scripts.length - 1];
+    const namespace = currentScript.getAttribute('data-stellarwp-namespace');
 
-/**
- * Handles the dismissal of admin notices.
- *
- * @since 1.1.0 fixes potential event conflicts with notices not produced by this library
- * @since 1.0.0
- */
-jQuery(document).ready(function ($) {
-    const $notices = $('[data-stellarwp-notice-id]');
+    if (!namespace) {
+        console.error('The stellarwp/admin-notices library failed to load because the namespace attribute is missing.');
+        return;
+    }
+
+    window.stellarwp = window.stellarwp || {};
+    window.stellarwp.adminNotices = window.stellarwp.adminNotices || {};
+    window.stellarwp.adminNotices[namespace] = {
+        /**
+         * Dismisses a notice with the given ID.
+         *
+         * @since 1.1.0
+         *
+         * @param {string} noticeId
+         */
+        dismissNotice: function (noticeId) {
+            const now = Math.floor(Date.now() / 1000);
+            dispatch('core/preferences').set(`stellarwp/${namespace}/admin-notices`, noticeId, now);
+        },
+    };
+
+    // Begin notice dismissal code
+    const noticeIdAttribute = `data-stellarwp-${namespace}-notice-id`;
+    const $notices = $(`[${noticeIdAttribute}]`);
 
     $notices.on('click', '.notice-dismiss', function (event) {
-        const noticeId = $(this).closest('[data-stellarwp-notice-id]').data('stellarwp-notice-id');
+        const noticeId = $(this).closest(`[${noticeIdAttribute}]`).data(`stellarwp-${namespace}-notice-id`);
 
-        window.stellarwp.adminNotices.dismissNotice(noticeId);
+        window.stellarwp.adminNotices[namespace].dismissNotice(noticeId);
     });
-});
+})(window.jQuery, window.wp.data.dispatch, document);

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -1,13 +1,30 @@
-jQuery(document).ready(function ($) {
-    const {dispatch} = wp.data;
-    const dismissButtons = $('.notice-dismiss');
-
-    dismissButtons.on('click', function (event) {
-        const $this = $(this);
-        const container = $this.closest('.notice');
-        const noticeId = container.data('notice-id');
-
+window.stellarwp = window.stellarwp || {};
+window.stellarwp.adminNotices = {
+    /**
+     * Dismisses a notice with the given ID.
+     *
+     * @since 1.1.0
+     *
+     * @param {string} noticeId
+     */
+    dismissNotice: function (noticeId) {
         const now = Math.floor(Date.now() / 1000);
-        dispatch('core/preferences').set('stellarwp/admin-notices', noticeId, now);
+        wp.data.dispatch('core/preferences').set('stellarwp/admin-notices', noticeId, now);
+    },
+};
+
+/**
+ * Handles the dismissal of admin notices.
+ *
+ * @since 1.1.0 fixes potential event conflicts with notices not produced by this library
+ * @since 1.0.0
+ */
+jQuery(document).ready(function ($) {
+    const $notices = $('[data-stellarwp-notice-id]');
+
+    $notices.on('click', '.notice-dismiss', function (event) {
+        const noticeId = $(this).closest('[data-stellarwp-notice-id]').data('stellarwp-notice-id');
+
+        window.stellarwp.adminNotices.dismissNotice(noticeId);
     });
 });

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -20,7 +20,7 @@
          */
         dismissNotice: function (noticeId) {
             const now = Math.floor(Date.now() / 1000);
-            dispatch('core/preferences').set(`stellarwp/${namespace}/admin-notices`, noticeId, now);
+            dispatch('core/preferences').set(`stellarwp/admin-notices/${namespace}`, noticeId, now);
         },
     };
 

--- a/tests/unit/Actions/DisplayNoticesInAdminTest.php
+++ b/tests/unit/Actions/DisplayNoticesInAdminTest.php
@@ -43,7 +43,7 @@ class DisplayNoticesInAdminTest extends TestCase
      */
     public function testShouldEchoNothingWithNoNotices(): void
     {
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         $this->expectOutputString('');
         $displayNoticesInAdmin();
@@ -54,7 +54,7 @@ class DisplayNoticesInAdminTest extends TestCase
      */
     public function testShouldAcceptMultipleNotices(): void
     {
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice1 = $this->getSimpleMockNotice('foo');
         $notice2 = $this->getSimpleMockNotice('bar');
 
@@ -70,7 +70,7 @@ class DisplayNoticesInAdminTest extends TestCase
      */
     public function testPassesDateLimits(AdminNotice $notice, bool $shouldPass): void
     {
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         if ($shouldPass) {
             $this->expectOutputString('foo');
@@ -108,7 +108,7 @@ class DisplayNoticesInAdminTest extends TestCase
      */
     public function testPassesWhenCallback(AdminNotice $notice, bool $shouldPass): void
     {
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         if ($shouldPass) {
             $this->expectOutputString('foo');
@@ -149,7 +149,7 @@ class DisplayNoticesInAdminTest extends TestCase
      */
     public function testPassesUserCapabilities(AdminNotice $notice, bool $shouldPass): void
     {
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         if ($shouldPass) {
             $this->expectOutputString('foo');
@@ -195,7 +195,7 @@ class DisplayNoticesInAdminTest extends TestCase
 
     public function testShouldPassScreenConditionsWhenThereAreNoConditions(): void
     {
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo');
 
         $this->expectOutputString('foo');
@@ -206,7 +206,7 @@ class DisplayNoticesInAdminTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = 'http://example.com/wp-admin/dashboard.php';
 
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo')->on('~Dashboard~i'); // check regex flags, too
 
         $this->expectOutputString('foo');
@@ -217,7 +217,7 @@ class DisplayNoticesInAdminTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = 'http://example.com/wp-admin/dashboard.php';
 
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo')->on('dashboard');
 
         $this->expectOutputString('foo');
@@ -231,7 +231,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $this->set_fn_return('get_current_screen', (object)['base' => 'dashboard']);
 
         // mock get_current_screen() global function
-        $displayNoticesInAdmin = new DisplayNoticesInAdmin();
+        $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo')->on(['base' => 'dashboard']);
 
         $this->expectOutputString('foo');

--- a/tests/unit/Actions/RenderAdminNoticeTest.php
+++ b/tests/unit/Actions/RenderAdminNoticeTest.php
@@ -36,7 +36,7 @@ class RenderAdminNoticeTest extends TestCase
         $renderAdminNotice = new RenderAdminNotice($notice);
 
         $this->assertEquals(
-            "<div class='notice notice-info' data-notice-id='test_id'>Hello world!</div>",
+            "<div class='notice notice-info' data-stellarwp-notice-id='test_id'>Hello world!</div>",
             $renderAdminNotice()
         );
     }
@@ -53,7 +53,7 @@ class RenderAdminNoticeTest extends TestCase
         $renderAdminNotice = new RenderAdminNotice($notice);
 
         $this->assertEquals(
-            "<div class='notice notice-info is-dismissible' data-notice-id='test_id'>Hello world!</div>",
+            "<div class='notice notice-info is-dismissible' data-stellarwp-notice-id='test_id'>Hello world!</div>",
             $renderAdminNotice()
         );
     }
@@ -71,7 +71,7 @@ class RenderAdminNoticeTest extends TestCase
         $textWithAutoParagraphs = wpautop('Hello world!');
 
         $this->assertEquals(
-            "<div class='notice notice-info' data-notice-id='test_id'>$textWithAutoParagraphs</div>",
+            "<div class='notice notice-info' data-stellarwp-notice-id='test_id'>$textWithAutoParagraphs</div>",
             $renderAdminNotice()
         );
     }
@@ -90,7 +90,7 @@ class RenderAdminNoticeTest extends TestCase
         $renderAdminNotice = new RenderAdminNotice($notice);
 
         $this->assertEquals(
-            "<div class='notice notice-info' data-notice-id='test_id'>Hello world!</div>",
+            "<div class='notice notice-info' data-stellarwp-notice-id='test_id'>Hello world!</div>",
             $renderAdminNotice()
         );
     }

--- a/tests/unit/Actions/RenderAdminNoticeTest.php
+++ b/tests/unit/Actions/RenderAdminNoticeTest.php
@@ -17,9 +17,9 @@ class RenderAdminNoticeTest extends TestCase
             ->withoutAutoParagraph()
             ->withoutWrapper();
 
-        $renderAdminNotice = new RenderAdminNotice($notice);
+        $renderAdminNotice = new RenderAdminNotice('namespace');
 
-        $this->assertEquals('Hello world!', $renderAdminNotice());
+        $this->assertEquals('Hello world!', $renderAdminNotice($notice));
     }
 
     /**
@@ -33,11 +33,11 @@ class RenderAdminNoticeTest extends TestCase
             ->withoutAutoParagraph()
             ->notDismissible();
 
-        $renderAdminNotice = new RenderAdminNotice($notice);
+        $renderAdminNotice = new RenderAdminNotice('namespace');
 
         $this->assertEquals(
-            "<div class='notice notice-info' data-stellarwp-notice-id='test_id'>Hello world!</div>",
-            $renderAdminNotice()
+            "<div class='notice notice-info' data-stellarwp-namespace-notice-id='test_id'>Hello world!</div>",
+            $renderAdminNotice($notice)
         );
     }
 
@@ -50,11 +50,11 @@ class RenderAdminNoticeTest extends TestCase
             ->withoutAutoParagraph()
             ->dismissible();
 
-        $renderAdminNotice = new RenderAdminNotice($notice);
+        $renderAdminNotice = new RenderAdminNotice('namespace');
 
         $this->assertEquals(
-            "<div class='notice notice-info is-dismissible' data-stellarwp-notice-id='test_id'>Hello world!</div>",
-            $renderAdminNotice()
+            "<div class='notice notice-info is-dismissible' data-stellarwp-namespace-notice-id='test_id'>Hello world!</div>",
+            $renderAdminNotice($notice)
         );
     }
 
@@ -67,12 +67,12 @@ class RenderAdminNoticeTest extends TestCase
             ->autoParagraph()
             ->notDismissible();
 
-        $renderAdminNotice = new RenderAdminNotice($notice);
+        $renderAdminNotice = new RenderAdminNotice('namespace');
         $textWithAutoParagraphs = wpautop('Hello world!');
 
         $this->assertEquals(
-            "<div class='notice notice-info' data-stellarwp-notice-id='test_id'>$textWithAutoParagraphs</div>",
-            $renderAdminNotice()
+            "<div class='notice notice-info' data-stellarwp-namespace-notice-id='test_id'>$textWithAutoParagraphs</div>",
+            $renderAdminNotice($notice)
         );
     }
 
@@ -87,11 +87,11 @@ class RenderAdminNoticeTest extends TestCase
             ->withoutAutoParagraph()
             ->notDismissible();
 
-        $renderAdminNotice = new RenderAdminNotice($notice);
+        $renderAdminNotice = new RenderAdminNotice('namespace');
 
         $this->assertEquals(
-            "<div class='notice notice-info' data-stellarwp-notice-id='test_id'>Hello world!</div>",
-            $renderAdminNotice()
+            "<div class='notice notice-info' data-stellarwp-namespace-notice-id='test_id'>Hello world!</div>",
+            $renderAdminNotice($notice)
         );
     }
 }

--- a/tests/unit/AdminNoticesTest.php
+++ b/tests/unit/AdminNoticesTest.php
@@ -15,6 +15,11 @@ class AdminNoticesTest extends TestCase
 {
     use WithUopz;
 
+    protected function _before()
+    {
+        AdminNotices::initialize('namespace', 'https://example.com');
+    }
+
     /**
      * @covers ::show
      *
@@ -33,7 +38,7 @@ class AdminNoticesTest extends TestCase
         $notice = AdminNotices::show('test', 'This is a test message.');
         $this->assertInstanceOf(StellarWP\AdminNotices\AdminNotice::class, $notice);
         $this->assertEquals('This is a test message.', $notice->getRenderTextOrCallback());
-        $this->assertSame('/test', $notice->getId());
+        $this->assertSame('namespace/test', $notice->getId());
     }
 
     /**
@@ -48,7 +53,7 @@ class AdminNoticesTest extends TestCase
         AdminNotices::render($notice);
 
         $this->expectOutputString(
-            '<div class=\'notice notice-info\' data-notice-id=\'test\'>This is a test message.</div>'
+            '<div class=\'notice notice-info\' data-stellarwp-namespace-notice-id=\'test\'>This is a test message.</div>'
         );
     }
 
@@ -64,7 +69,7 @@ class AdminNoticesTest extends TestCase
         $html = AdminNotices::render($notice, false);
 
         $this->assertEquals(
-            '<div class=\'notice notice-info\' data-notice-id=\'test\'>This is a test message.</div>',
+            '<div class=\'notice notice-info\' data-stellarwp-namespace-notice-id=\'test\'>This is a test message.</div>',
             $html
         );
     }

--- a/tests/unit/AdminNoticesTest.php
+++ b/tests/unit/AdminNoticesTest.php
@@ -38,7 +38,7 @@ class AdminNoticesTest extends TestCase
         $notice = AdminNotices::show('test', 'This is a test message.');
         $this->assertInstanceOf(StellarWP\AdminNotices\AdminNotice::class, $notice);
         $this->assertEquals('This is a test message.', $notice->getRenderTextOrCallback());
-        $this->assertSame('namespace/test', $notice->getId());
+        $this->assertSame('test', $notice->getId());
     }
 
     /**

--- a/tests/unit/Traits/HasNamespaceTest.php
+++ b/tests/unit/Traits/HasNamespaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+
+use StellarWP\AdminNotices\Tests\Support\Helper\TestCase;
+use StellarWP\AdminNotices\Traits\HasNamespace;
+
+class HasNamespaceTest extends TestCase
+{
+    public function testShouldHaveNamespaceConstructorParameter(): void
+    {
+        $class = new ClassWithNamespace('namespace');
+        $this->assertEquals('namespace', $class->getNamespace());
+    }
+}
+
+class ClassWithNamespace
+{
+    use HasNamespace;
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+}


### PR DESCRIPTION
Prior to this PR, the JS was open to collisions with other plugins. It wasn't namespacing the functions and such properly, so it would've caused issues if multiple plugins were using different versions of this package. It also was only kind of namespsacing things within persistence, in a more complicated way.

In this PR, namespacing is added to the JS and attributes used to identify the notice. This way the plugin using the package will only ever affect it's own notices.

It also updated the way persistence worked. Now, within the user preferences meta, the root key is `stellarwp/admin-notices-$namespace`. This means that the stored notification ids no longer need to be namespaced (saving a bit of room), and the user's notices can be reset simply by removing the array as a whole.

All in all, this makes the package better at avoiding plugin conflict and simplifies the persistence of dismissed notices.