### PR TITLE
Feature: Adds ability to set a notice as 'inline'

### DIFF
--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -52,7 +52,7 @@ class RenderAdminNotice
             $classes[] = "is-dismissible";
         }
 
-        if ($this->notice->isInline()) {
+        if ($notice->isInline()) {
             $classes[] = 'inline';
         }
 

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -52,6 +52,10 @@ class RenderAdminNotice
             $classes[] = "is-dismissible";
         }
 
+        if ($this->notice->isInline()) {
+            $classes[] = 'inline';
+        }
+
         return implode(' ', $classes);
     }
 }

--- a/src/AdminNotice.php
+++ b/src/AdminNotice.php
@@ -285,7 +285,7 @@ class AdminNotice
     /**
      * Returns whether the notice is inline
      *
-     * @since TBD
+     * @unreleased
      */
     public function isInline(): bool
     {
@@ -295,7 +295,7 @@ class AdminNotice
     /**
      * Sets the notice to be inline
      *
-     * @since TBD
+     * @unreleased
      */
     public function inline(bool $inline = true): self
     {
@@ -307,7 +307,7 @@ class AdminNotice
     /**
      * Sets the notice to be not inline
      *
-     * @since TBD
+     * @unreleased
      */
     public function notInline(): self
     {

--- a/src/AdminNotice.php
+++ b/src/AdminNotice.php
@@ -65,7 +65,15 @@ class AdminNotice
      */
     protected $withWrapper = true;
 
+    /**
+     * @var bool
+     */
     protected $dismissible = false;
+
+    /**
+     * @var bool
+     */
+    protected $inline = false;
 
     /**
      * @since 1.0.0
@@ -270,6 +278,40 @@ class AdminNotice
     public function withoutWrapper(): self
     {
         $this->withWrapper = false;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether the notice is inline
+     *
+     * @since TBD
+     */
+    public function isInline(): bool
+    {
+        return $this->inline;
+    }
+
+    /**
+     * Sets the notice to be inline
+     *
+     * @since TBD
+     */
+    public function inline(bool $inline = true): self
+    {
+        $this->inline = $inline;
+
+        return $this;
+    }
+
+    /**
+     * Sets the notice to be not inline
+     *
+     * @since TBD
+     */
+    public function notInline(): self
+    {
+        $this->inline = false;
 
         return $this;
     }

--- a/tests/unit/AdminNoticeTest.php
+++ b/tests/unit/AdminNoticeTest.php
@@ -245,6 +245,38 @@ class AdminNoticeTest extends TestCase
     }
 
     /**
+     * @covers ::inline
+     * @covers ::notInline
+     * @covers ::isInline
+     *
+     * @unreleased
+     */
+    public function testInline(): void
+    {
+        // Defaults to false
+        $notice = new AdminNotice('test_id', 'test');
+        $this->assertFalse($notice->isInline());
+
+        // Method defaults to true
+        $self = $notice->inline();
+        $this->assertTrue($notice->isInline());
+        $this->assertSame($notice, $self);
+
+        // Method can be explicitly set to false
+        $notice->inline(false);
+        $this->assertFalse($notice->isInline());
+
+        // Method can be set to true
+        $notice->inline(true);
+        $this->assertTrue($notice->isInline());
+
+        // notInline is an alias for inline(false)
+        $self = $notice->notInline();
+        $this->assertFalse($notice->isInline());
+        $this->assertSame($notice, $self);
+    }
+
+    /**
      * @covers ::dismissible
      * @covers ::notDismissible
      * @covers ::isDismissible


### PR DESCRIPTION
This just adds the ability to `inline` a notice, which will bypass the Wordpress default behavior of moving the dom node into the main admin notices container on the top of pages.

![image](https://github.com/user-attachments/assets/a9c05841-3a5b-442b-83c0-ee2855e1c49c)
