### PR TITLE
Feature: adds support for alternate WP styles

### DIFF
--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -51,6 +51,10 @@ class RenderAdminNotice
             $classes[] = 'is-dismissible';
         }
 
+        if ($this->notice->usesAlternateStyles()) {
+            $classes[] = 'notice-alt';
+        }
+
         return implode(' ', $classes);
     }
 }

--- a/src/AdminNotice.php
+++ b/src/AdminNotice.php
@@ -63,8 +63,16 @@ class AdminNotice
     /**
      * @var bool
      */
+    protected $alternateStyles = false;
+
+    /**
+     * @var bool
+     */
     protected $withWrapper = true;
 
+    /**
+     * @var bool
+     */
     protected $dismissible = false;
 
     /**
@@ -230,24 +238,78 @@ class AdminNotice
         return $this;
     }
 
+    /**
+     * Alias for setting the urgency to info
+     *
+     * @since 1.1.0
+     */
     public function asInfo(): self
     {
         return $this->urgency(NoticeUrgency::info());
     }
 
+    /**
+     * Alias for setting the urgency to success
+     *
+     * @since 1.1.0
+     */
     public function asSuccess(): self
     {
         return $this->urgency(NoticeUrgency::success());
     }
 
+    /**
+     * Alias for setting the urgency to warning
+     *
+     * @since 1.1.0
+     */
     public function asWarning(): self
     {
         return $this->urgency(NoticeUrgency::warning());
     }
 
+    /**
+     * Alias for setting the urgency to error
+     *
+     * @since 1.1.0
+     */
     public function asError(): self
     {
         return $this->urgency(NoticeUrgency::error());
+    }
+
+    /**
+     * Uses the alternate WP notice styles
+     *
+     * @unreleased
+     */
+    public function alternateStyles(bool $altStyle = true): self
+    {
+        $this->alternateStyles = $altStyle;
+
+        return $this;
+    }
+
+    /**
+     * Uses the standard WP notice styles
+     *
+     * @unreleased
+     */
+    public function standardStyles(): self
+    {
+        $this->alternateStyles = false;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether the notice uses the alternate WP notice styles
+     *
+     * @unreleased
+     */
+    public function usesAlternateStyles(): bool
+    {
+        return $this->alternateStyles;
     }
 
     /**

--- a/tests/unit/Actions/DisplayNoticesInAdminTest.php
+++ b/tests/unit/Actions/DisplayNoticesInAdminTest.php
@@ -21,7 +21,7 @@ class DisplayNoticesInAdminTest extends TestCase
     protected $originalServer;
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     protected function setUp(): void
     {
@@ -30,7 +30,7 @@ class DisplayNoticesInAdminTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     protected function tearDown(): void
     {
@@ -39,7 +39,7 @@ class DisplayNoticesInAdminTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldEchoNothingWithNoNotices(): void
     {
@@ -50,7 +50,7 @@ class DisplayNoticesInAdminTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldAcceptMultipleNotices(): void
     {
@@ -66,7 +66,7 @@ class DisplayNoticesInAdminTest extends TestCase
      * @covers ::passesDateLimits
      * @dataProvider passDateLimitsDataProvider
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testPassesDateLimits(AdminNotice $notice, bool $shouldPass): void
     {
@@ -104,7 +104,7 @@ class DisplayNoticesInAdminTest extends TestCase
      * @dataProvider passWhenCallbackDataProvider
      * @covers ::passesWhenCallback
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testPassesWhenCallback(AdminNotice $notice, bool $shouldPass): void
     {
@@ -120,7 +120,7 @@ class DisplayNoticesInAdminTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function passWhenCallbackDataProvider(): array
     {
@@ -145,7 +145,7 @@ class DisplayNoticesInAdminTest extends TestCase
      * @dataProvider passUserCapabilitiesDataProvider
      * @covers ::passesUserCapabilities
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testPassesUserCapabilities(AdminNotice $notice, bool $shouldPass): void
     {
@@ -241,7 +241,7 @@ class DisplayNoticesInAdminTest extends TestCase
     /**
      * Produces a simple mock with predictable output.
      *
-     * @unreleased
+     * @since 1.0.0
      */
     private function getSimpleMockNotice($output): AdminNotice
     {

--- a/tests/unit/Actions/RenderAdminNoticeTest.php
+++ b/tests/unit/Actions/RenderAdminNoticeTest.php
@@ -9,7 +9,7 @@ use StellarWP\AdminNotices\Tests\Support\Helper\TestCase;
 class RenderAdminNoticeTest extends TestCase
 {
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldRenderNoticeWithoutWrapper(): void
     {
@@ -25,7 +25,7 @@ class RenderAdminNoticeTest extends TestCase
     /**
      * Tests the wrapper and that the default urgency is info
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldRenderNoticeInWrapper(): void
     {
@@ -42,7 +42,7 @@ class RenderAdminNoticeTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldIncludeDismissibleClass(): void
     {
@@ -59,7 +59,7 @@ class RenderAdminNoticeTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldIncludeAutoParagraphs(): void
     {
@@ -77,7 +77,7 @@ class RenderAdminNoticeTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldRenderCallbackOutput(): void
     {

--- a/tests/unit/AdminNoticeTest.php
+++ b/tests/unit/AdminNoticeTest.php
@@ -20,7 +20,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testThrowsExceptionWhenRenderIsNotStringOrCallable()
     {
@@ -31,7 +31,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::ifUserCan
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testIfUserCan(): void
     {
@@ -50,7 +50,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::ifUserCan
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testIfUserCanShouldThrowExceptionWhenCapabilityIsNotStringOrArray(): void
     {
@@ -62,7 +62,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::ifUserCan
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testIfUserCanShouldThrowExceptionWhenCapabilityArrayIsMisshaped(): void
     {
@@ -78,7 +78,7 @@ class AdminNoticeTest extends TestCase
      *
      * @dataProvider dateTestProvider
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testAfter($parameter, $assertDate): void
     {
@@ -96,7 +96,7 @@ class AdminNoticeTest extends TestCase
      *
      * @dataProvider dateTestProvider
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testUntil($parameter, $assertDate): void
     {
@@ -110,7 +110,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::between
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testBetween(): void
     {
@@ -136,7 +136,7 @@ class AdminNoticeTest extends TestCase
      * @covers ::when
      * @covers ::getWhenCallback
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testWhen(): void
     {
@@ -153,7 +153,7 @@ class AdminNoticeTest extends TestCase
      * @covers ::on
      * @covers ::getOnConditions
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testOn(): void
     {
@@ -169,7 +169,7 @@ class AdminNoticeTest extends TestCase
      * @covers ::withoutAutoParagraph
      * @covers ::shouldAutoParagraph
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testAutoParagraph(): void
     {
@@ -200,7 +200,7 @@ class AdminNoticeTest extends TestCase
      * @covers ::urgency
      * @covers ::getUrgency
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testUrgency(): void
     {
@@ -249,7 +249,7 @@ class AdminNoticeTest extends TestCase
      * @covers ::notDismissible
      * @covers ::isDismissible
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testDismissible(): void
     {
@@ -279,7 +279,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::getRenderTextOrCallback
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testGetRenderTextOrCallback(): void
     {
@@ -296,7 +296,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::getRenderedContent
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testRenderedContent(): void
     {
@@ -319,7 +319,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::getUserCapabilities
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testGetUserCapabilities(): void
     {
@@ -337,7 +337,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::getAfterDate
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testGetAfterDate(): void
     {
@@ -354,7 +354,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::getUntilDate
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testGetUntilDate(): void
     {
@@ -371,7 +371,7 @@ class AdminNoticeTest extends TestCase
     /**
      * @covers ::getWhenCallback
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testGetWhenCallback(): void
     {
@@ -383,5 +383,36 @@ class AdminNoticeTest extends TestCase
         $callback = function () {};
         $notice->when($callback);
         $this->assertSame($callback, $notice->getWhenCallback());
+    }
+
+    /**
+     * @covers ::alternateStyles
+     * @covers ::standardStyles
+     * @covers ::usesAlternateStyles
+     */
+    public function testAlternateStyles(): void
+    {
+        $notice = new AdminNotice('test_id', 'test');
+
+        // Defaults to false
+        $this->assertFalse($notice->usesAlternateStyles());
+
+        // Method can be set to true
+        $self = $notice->alternateStyles();
+        $this->assertTrue($notice->usesAlternateStyles());
+        $this->assertSame($notice, $self);
+
+        // Method can be explicitly set to false
+        $notice->alternateStyles(false);
+        $this->assertFalse($notice->usesAlternateStyles());
+
+        // Method can be set to true
+        $notice->alternateStyles(true);
+        $this->assertTrue($notice->usesAlternateStyles());
+
+        // standardStyles is an alias for alternateStyles(false)
+        $self = $notice->standardStyles();
+        $this->assertFalse($notice->usesAlternateStyles());
+        $this->assertSame($notice, $self);
     }
 }

--- a/tests/unit/NotificationsRegistrarTest.php
+++ b/tests/unit/NotificationsRegistrarTest.php
@@ -15,7 +15,7 @@ class NotificationsRegistrarTest extends TestCase
      * @covers ::registerNotice
      * @covers ::getNotices
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testRegisterNotice(): void
     {
@@ -29,7 +29,7 @@ class NotificationsRegistrarTest extends TestCase
     /**
      * @covers ::unregisterNotice
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testUnregisterNotice(): void
     {

--- a/tests/unit/ValueObjects/NoticeUrgencyTest.php
+++ b/tests/unit/ValueObjects/NoticeUrgencyTest.php
@@ -16,7 +16,7 @@ class NoticeUrgencyTest extends TestCase
 {
     /**
      * @covers ::info
-     * @unreleased
+     * @since 1.0.0
      */
     public function testInfo(): void
     {
@@ -25,7 +25,7 @@ class NoticeUrgencyTest extends TestCase
 
     /**
      * @covers ::warning
-     * @unreleased
+     * @since 1.0.0
      */
     public function testWarning(): void
     {
@@ -34,7 +34,7 @@ class NoticeUrgencyTest extends TestCase
 
     /**
      * @covers ::error
-     * @unreleased
+     * @since 1.0.0
      */
     public function testError(): void
     {
@@ -43,7 +43,7 @@ class NoticeUrgencyTest extends TestCase
 
     /**
      * @covers ::success
-     * @unreleased
+     * @since 1.0.0
      */
     public function testSuccess(): void
     {
@@ -52,7 +52,7 @@ class NoticeUrgencyTest extends TestCase
 
     /**
      * @covers ::__toString
-     * @unreleased
+     * @since 1.0.0
      */
     public function testToString(): void
     {
@@ -63,7 +63,7 @@ class NoticeUrgencyTest extends TestCase
      * @covers ::__construct
      * @dataProvider constructorTestDataProvider
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testConstructorValidation($value, $shouldPass): void
     {
@@ -76,7 +76,7 @@ class NoticeUrgencyTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function constructorTestDataProvider(): array
     {

--- a/tests/unit/ValueObjects/ScreenConditionTest.php
+++ b/tests/unit/ValueObjects/ScreenConditionTest.php
@@ -20,7 +20,7 @@ class ScreenConditionTest extends TestCase
     /**
      * @covers ::isRegex
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testIsRegex(): void
     {
@@ -44,7 +44,7 @@ class ScreenConditionTest extends TestCase
     /**
      * @covers ::getCondition
      *
-     * @unreleased
+     * @since 1.0.0
      */
     public function testGetCondition(): void
     {
@@ -53,7 +53,7 @@ class ScreenConditionTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldThrowExceptionWithNonStringOrArray(): void
     {
@@ -62,7 +62,7 @@ class ScreenConditionTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldThrowExceptionWithNonAssociativeArray(): void
     {
@@ -71,7 +71,7 @@ class ScreenConditionTest extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 1.0.0
      */
     public function testShouldThrowExceptionForInvalidWPScreenProperties(): void
     {


### PR DESCRIPTION
This adds support for the `notice-alt` WP styling (the latter, below):

<img width="430" alt="image" src="https://github.com/user-attachments/assets/d87c1933-43ff-4cd7-b915-38906b1a4b11">

It's pretty straightforward and defaults to the standard styling, so it's backwards compatible.