### PR TITLE
Fix: Use `strpos()` instead of `str_contains()` for PHP 7.4 Compatibility

### DIFF
--- a/src/Actions/DisplayNoticesInAdmin.php
+++ b/src/Actions/DisplayNoticesInAdmin.php
@@ -141,7 +141,7 @@ class DisplayNoticesInAdmin
                 }
             } elseif (is_string($condition)) {
                 // do a string comparison on the current url
-                if (str_contains($currentUrl, $condition)) {
+                if (strpos($currentUrl, $condition) !== false) {
                     return true;
                 }
             } else {


### PR DESCRIPTION
I was implementing this library in LearnDash Core and our CI checks for PHP Compatibility going back to PHP 7.4. This was the only issue that was flagged and it is a simple fix, so I figure it would be worthwhile swapping this out.

Here's a link to the failed CI run: https://github.com/stellarwp/learndash-core/actions/runs/11445084887/job/31841419401?pr=1237