### PR TITLE
Fix: user preferences retrieval in site with custom DB prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "stellarwp/admin-notices",
-    "version": "1.2.1",
     "description": "A handy package for easily displaying admin notices in WordPress with simple to complex visibility conditions",
     "minimum-stability": "stable",
     "license": "MIT",

--- a/src/Actions/DisplayNoticesInAdmin.php
+++ b/src/Actions/DisplayNoticesInAdmin.php
@@ -165,7 +165,9 @@ class DisplayNoticesInAdmin
      */
     private function passesDismissedConditions(AdminNotice $notice): bool
     {
-        $userPreferences = get_user_meta(get_current_user_id(), 'wp_persisted_preferences', true);
+        global $wpdb;
+
+        $userPreferences = get_user_meta(get_current_user_id(), $wpdb->get_blog_prefix() . 'persisted_preferences', true);
 
         $key = "stellarwp/admin-notices/$this->namespace";
         if (!is_array($userPreferences) || empty($userPreferences[$key])) {


### PR DESCRIPTION
When I was working with the dismissible feature of the Admin Notices, a dismissed notice keeps appearing after being dismissed by a user. 

The issue turns out the user meta key for persisted preference is prefixed by `$wpdb->get_blog_prefix` as we can see from the `wp-includes/user.php` file inside the `wp_register_persisted_preferences_meta()` function:

```php
global $wpdb;
$meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
```

This PR fixes the same meta key name we use in the Admin Notices.