### PR TITLE
Feature: rebuild support for custom notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ $renderCallback = function (AdminNotice $notice, NoticeElementProperties $elemen
     return "
         <div>
             <p>This is a custom notice</p>
-            <button type='button' {$elements->customCloserAttributes()}>
+            <button type='button' {$elements->closeAttributes()}>
                 <span class='screen-reader-text'>Dismiss this notice.</span>
             </button>
         </div>

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Parameters:
 1. `string $id` - A unique identifier for the notice.
 2. `string|callback $message` - The message to display. This can be a string or a callback that
    returns a string. The callback receives an instance of the `AdminNotice` class and an instance of
-   the `NoticeElementProperties` class — the latter of which is useful for custom notices.
+   the [NoticeElementProperties](src/DataTransferObjects/NoticeElementProperties.php) class — the
+   latter of which is useful for custom notices.
 
 ```php
 use StellarWP\AdminNotices\AdminNotices;
@@ -483,10 +484,11 @@ AdminNotices::show('my_notice', $renderCallback)
     ->custom();
 ```
 
-The `$elements` object provides a `customCloserAttributes` method that returns the necessary
-attributes to be place on the dismiss button. This method will add the necessary attributes to
-dismiss the notice when clicked. This will permanently dismiss the notice, and fade out the notice,
-similar to the standard WordPress dismissible notices.
+The [$elements](src/DataTransferObjects/NoticeElementProperties.php) object provides a
+`customCloserAttributes` method that returns the necessary attributes to be place on the dismiss
+button. This method will add the necessary attributes to dismiss the notice when clicked. This will
+permanently dismiss the notice, and fade out the notice, similar to the standard WordPress
+dismissible notices.
 
 If you want the notice to be marked as dismissed, but not fade out, you can pass "clear" to the
 `customerCloserAttributes` method: e.g. `$elements->customCloserAttributes('clear')`.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ Parameters:
 
 1. `string $id` - A unique identifier for the notice.
 2. `string|callback $message` - The message to display. This can be a string or a callback that
-   returns a string
+   returns a string. The callback receives an instance of the `AdminNotice` class and an instance of
+   the `NoticeElementProperties` class — the latter of which is useful for custom notices.
 
 ```php
 use StellarWP\AdminNotices\AdminNotices;
+use StellarWP\AdminNotices\AdminNotice;
+use \StellarWP\AdminNotices\DataTransferObjects\NoticeElementProperties;
 
 AdminNotices::show('my_notice', 'This is a notice');
-AdminNotices::show('my_notice', function () {
+AdminNotices::show('my_notice', function (AdminNotice $notice, NoticeElementProperties $elements) {
     return 'This is a notice';
 });
 ```
@@ -287,7 +290,7 @@ $notice = AdminNotices::show('my_notice', 'This is a notice')
     });
 ```
 
-## Visual & behavior options
+## Standard Notice Visual & behavior options
 
 ### `autoParagraph($autoParagraph)`, `withoutAutoParagraph()`
 
@@ -314,32 +317,6 @@ $notice = AdminNotices::show('my_notice', 'This is a notice')
 // Also has an alias for readability
 $notice = AdminNotices::show('my_notice', 'This is a notice')
     ->withoutAutoParagraph();
-```
-
-### `withWrapper($with)`, `withoutWrapper()`
-
-**Default:** true
-
-Sets whether the rendered notice should be wrapped in the standard WordPress notice wrapper.
-
-Parameters:
-
-1. `bool $with = true` - Whether to wrap the notice in the standard WordPress notice wrapper
-
-```php
-use StellarWP\AdminNotices\AdminNotices;
-
-// Wrap the notice in the standard WordPress notice wrapper
-$notice = AdminNotices::show('my_notice', 'This is a notice')
-    ->withWrapper();
-
-// Do not wrap the notice in the standard WordPress notice wrapper
-$notice = AdminNotices::show('my_notice', 'This is a notice')
-    ->withWrapper(false);
-
-// Also has an alias for readability
-$notice = AdminNotices::show('my_notice', 'This is a notice')
-    ->withoutWrapper();
 ```
 
 ### `urgency($urgency)`
@@ -445,6 +422,74 @@ $notice = AdminNotices::show('my_notice', 'This is a notice')
 $notice = AdminNotices::show('my_notice', 'This is a notice')
     ->notDismissible();
 ```
+
+## Custom Notices
+
+Sometimes you want to display a notice, but you want to completely style it yourself. This is
+possible and pretty straightforward to do.
+
+Start by using the `custom` method on the notice. This will disable all standard visual and behavior
+
+```php
+use StellarWP\AdminNotices\AdminNotices;
+
+$notice = AdminNotices::show('my_notice_custom', 'This is a notice')
+    ->custom();
+```
+
+### `location()`
+
+***Default:*** 'standard'
+
+Sets the location in one of the standard WordPress notice locations. By default, the notice will be
+displayed in the standard location.
+
+Parameters:
+
+1. `string $location` - The location to display the notice. Can be 'standard', 'above_header', '
+   below_header', or 'inline'. Note that 'standard' and 'below_header' are the same location.
+
+```php
+use StellarWP\AdminNotices\AdminNotices;
+
+// Display the notice above the header
+$notice = AdminNotices::show('my_notice_custom', 'This is a notice')
+    ->custom()
+    ->location('above_header');
+```
+
+### Dismissing
+
+The `dismissible` method is not available for custom notices. If you want to add a dismiss button,
+you will need to do so manually. Fortunately, there is a simple way to do this.
+
+```php
+use StellarWP\AdminNotices\AdminNotices;
+use StellarWP\AdminNotices\AdminNotice;
+use \StellarWP\AdminNotices\DataTransferObjects\NoticeElementProperties;
+
+$renderCallback = function (AdminNotice $notice, NoticeElementProperties $elements) {
+    return "
+        <div>
+            <p>This is a custom notice</p>
+            <button type='button' {$elements->customCloserAttributes()}>
+                <span class='screen-reader-text'>Dismiss this notice.</span>
+            </button>
+        </div>
+    ";
+};
+
+AdminNotices::show('my_notice', $renderCallback)
+    ->custom();
+```
+
+The `$elements` object provides a `customCloserAttributes` method that returns the necessary
+attributes to be place on the dismiss button. This method will add the necessary attributes to
+dismiss the notice when clicked. This will permanently dismiss the notice, and fade out the notice,
+similar to the standard WordPress dismissible notices.
+
+If you want the notice to be marked as dismissed, but not fade out, you can pass "clear" to the
+`customerCloserAttributes` method: e.g. `$elements->customCloserAttributes('clear')`.
 
 ## Resetting dismissed notices
 

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -77,7 +77,7 @@ class RenderAdminNotice
             $classes[] = "is-dismissible";
         }
 
-        if ($notice->isInline()) {
+        if ($notice->getLocation()->isInline()) {
             $classes[] = 'inline';
         }
 

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -71,7 +71,7 @@ class RenderAdminNotice
             $classes[] = "is-dismissible";
         }
 
-        if ($notice->getLocation()->isInline()) {
+        if ($notice->getLocation() && $notice->getLocation()->isInline()) {
             $classes[] = 'inline';
         }
 

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -38,10 +38,6 @@ class RenderAdminNotice
             $content = $renderTextOrCallback;
         }
 
-        if (!$notice->isCustom() && $notice->shouldAutoParagraph()) {
-            $content = wpautop($content);
-        }
-
         if ($notice->isCustom()) {
             return $this->applyCustomAttributesToContent($content, $notice);
         }
@@ -49,7 +45,7 @@ class RenderAdminNotice
         return sprintf(
             "<div class='%s' $elementProperties->idAttribute>%s</div>",
             esc_attr($this->getStandardWrapperClasses($notice)),
-            $content
+            $notice->shouldAutoParagraph() ? wpautop($content) : $content
         );
     }
 

--- a/src/Actions/RenderAdminNotice.php
+++ b/src/Actions/RenderAdminNotice.php
@@ -98,7 +98,7 @@ class RenderAdminNotice
         $tags->set_attribute("data-stellarwp-{$this->namespace}-notice-id", $notice->getId());
 
         if ($notice->getLocation()) {
-            $tags->set_attribute("data-stellarwp-{$this->namespace}-location", $notice->getLocation());
+            $tags->set_attribute("data-stellarwp-{$this->namespace}-location", (string)$notice->getLocation());
         }
 
         return $tags->__toString();

--- a/src/AdminNotice.php
+++ b/src/AdminNotice.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
+use StellarWP\AdminNotices\ValueObjects\NoticeLocation;
 use StellarWP\AdminNotices\ValueObjects\NoticeUrgency;
 use StellarWP\AdminNotices\ValueObjects\ScreenCondition;
 use StellarWP\AdminNotices\ValueObjects\UserCapability;
@@ -66,9 +67,9 @@ class AdminNotice
     protected $alternateStyles = false;
 
     /**
-     * @var bool
+     * @var bool Indicates that the notice is customized and not the standard WordPress notice
      */
-    protected $withWrapper = true;
+    protected $custom = false;
 
     /**
      * @var bool
@@ -76,9 +77,9 @@ class AdminNotice
     protected $dismissible = false;
 
     /**
-     * @var bool
+     * @var NoticeLocation|null
      */
-    protected $inline = false;
+    protected $location;
 
     /**
      * @since 1.0.0
@@ -94,6 +95,7 @@ class AdminNotice
         $this->id = $id;
         $this->renderTextOrCallback = $renderTextOrCallback;
         $this->urgency = NoticeUrgency::info();
+        $this->location = NoticeLocation::standard();
     }
 
     /**
@@ -317,26 +319,16 @@ class AdminNotice
         return $this->alternateStyles;
     }
 
-    /**
-     * Sets the notice to display without the standard WordPress wrapper
-     *
-     * @since 1.0.0
-     */
-    public function withWrapper(bool $withWrapper = true): self
+    public function custom(bool $custom = true): self
     {
-        $this->withWrapper = $withWrapper;
+        $this->custom = $custom;
 
         return $this;
     }
 
-    /**
-     * Sets the notice to display without the standard WordPress wrapper
-     *
-     * @since 1.0.0
-     */
-    public function withoutWrapper(): self
+    public function standard(): self
     {
-        $this->withWrapper = false;
+        $this->custom = false;
 
         return $this;
     }
@@ -348,7 +340,7 @@ class AdminNotice
      */
     public function isInline(): bool
     {
-        return $this->inline;
+        return $this->location->isInline();
     }
 
     /**
@@ -358,21 +350,21 @@ class AdminNotice
      */
     public function inline(bool $inline = true): self
     {
-        $this->inline = $inline;
+        $this->location = NoticeLocation::inline();
 
         return $this;
     }
 
-    /**
-     * Sets the notice to be not inline
-     *
-     * @since 1.2.0
-     */
-    public function notInline(): self
+    public function location($location): self
     {
-        $this->inline = false;
+        $this->location = $location instanceof NoticeLocation ? $location : new NoticeLocation($location);
 
         return $this;
+    }
+
+    public function getLocation(): ?NoticeLocation
+    {
+        return $this->location;
     }
 
     /**
@@ -509,14 +501,9 @@ class AdminNotice
         return $this->urgency;
     }
 
-    /**
-     * Returns whether the notice should be displayed with the standard WordPress wrapper
-     *
-     * @since 1.0.0
-     */
-    public function usesWrapper(): bool
+    public function isCustom(): bool
     {
-        return $this->withWrapper;
+        return $this->custom;
     }
 
     /**

--- a/src/AdminNotice.php
+++ b/src/AdminNotice.php
@@ -334,23 +334,26 @@ class AdminNotice
     }
 
     /**
-     * Returns whether the notice is inline
+     * Sets the notice to be inline
      *
+     * @unreleased removed parameter in favor of new location parameter
      * @since 1.2.0
      */
-    public function isInline(): bool
+    public function inline(): self
     {
-        return $this->location->isInline();
+        $this->location = NoticeLocation::inline();
+
+        return $this;
     }
 
     /**
-     * Sets the notice to be inline
+     * Prevents the notice from being moved from the place it's rendered
      *
-     * @since 1.2.0
+     * @unreleased
      */
-    public function inline(bool $inline = true): self
+    public function inPlace(): self
     {
-        $this->location = NoticeLocation::inline();
+        $this->location = null;
 
         return $this;
     }

--- a/src/AdminNotices.php
+++ b/src/AdminNotices.php
@@ -49,8 +49,9 @@ class AdminNotices
     }
 
     /**
-     * Immediately renders a notice, useful when wanting to display a notice in an ad hoc context
+     * Renders the notice in the current location while still honoring visibility conditions
      *
+     * @unreleased mark notice as inPlace to prevent movement; return null if not being rendered
      * @since 1.0.0
      *
      * @param bool $echo whether to echo or return the notice
@@ -60,7 +61,7 @@ class AdminNotices
     public static function render(AdminNotice $notice, bool $echo = true): ?string
     {
         ob_start();
-        (new DisplayNoticesInAdmin(self::$namespace))($notice);
+        (new DisplayNoticesInAdmin(self::$namespace))($notice->inPlace());
         $output = ob_get_clean();
 
         if ($echo) {
@@ -68,7 +69,7 @@ class AdminNotices
 
             return null;
         } else {
-            return $output;
+            return $output ?: null;
         }
     }
 

--- a/src/DataTransferObjects/NoticeElementProperties.php
+++ b/src/DataTransferObjects/NoticeElementProperties.php
@@ -69,7 +69,7 @@ class NoticeElementProperties
      *
      * @param 'hide'|'clear' $behavior
      */
-    public function customCloserAttributes(string $behavior = 'hide'): string
+    public function closeAttributes(string $behavior = 'hide'): string
     {
         if (!in_array($behavior, ['hide', 'clear'], true)) {
             throw new InvalidArgumentException('Invalid behavior for custom closer attribute.');

--- a/src/DataTransferObjects/NoticeElementProperties.php
+++ b/src/DataTransferObjects/NoticeElementProperties.php
@@ -11,24 +11,27 @@ use StellarWP\AdminNotices\AdminNotice;
 class NoticeElementProperties
 {
     /**
-     * @var string
+     * @var string custom namespace for the library instance
      */
     private $namespace;
 
     /**
-     * @var string
+     * @var string id attribute that uniquely identifies the notice
      */
     public $idAttribute;
 
+    /**
+     * @var string attribute to put on an element which closes the notice
+     */
     public $customCloserAttribute;
 
     /**
-     * @var string
+     * @var string attribute for custom notices which specifies the location
      */
     public $customLocationAttribute;
 
     /**
-     * @var string
+     * @var string attributes to be applied to custom notices
      */
     public $customWrapperAttributes;
 

--- a/src/DataTransferObjects/NoticeElementProperties.php
+++ b/src/DataTransferObjects/NoticeElementProperties.php
@@ -10,6 +10,9 @@ use StellarWP\AdminNotices\AdminNotice;
 
 class NoticeElementProperties
 {
+    private const CLOSE_BEHAVIOR_HIDE = 'hide';
+    private const CLOSE_BEHAVIOR_MARK_DISMISSED = 'mark-dismissed';
+
     /**
      * @var string custom namespace for the library instance
      */
@@ -53,11 +56,11 @@ class NoticeElementProperties
     /**
      * @unreleased
      *
-     * @param 'hide'|'clear' $behavior
+     * @param 'hide'|'mark-dismissed' $behavior
      */
-    public function customCloseBehaviorAttribute(string $behavior = 'hide'): string
+    public function customCloseBehaviorAttribute(string $behavior = self::CLOSE_BEHAVIOR_HIDE): string
     {
-        if (!in_array($behavior, ['hide', 'clear'], true)) {
+        if (!$this->behaviorIsValid($behavior)) {
             throw new InvalidArgumentException('Invalid behavior for custom closer attribute.');
         }
 
@@ -67,14 +70,22 @@ class NoticeElementProperties
     /**
      * @unreleased
      *
-     * @param 'hide'|'clear' $behavior
+     * @param 'hide'|'mark-dismissed' $behavior
      */
-    public function closeAttributes(string $behavior = 'hide'): string
+    public function closeAttributes(string $behavior = self::CLOSE_BEHAVIOR_HIDE): string
     {
-        if (!in_array($behavior, ['hide', 'clear'], true)) {
+        if (!$this->behaviorIsValid($behavior)) {
             throw new InvalidArgumentException('Invalid behavior for custom closer attribute.');
         }
 
         return "$this->customCloserAttribute {$this->customCloseBehaviorAttribute($behavior)}";
+    }
+
+    /**
+     * @unreleased
+     */
+    private function behaviorIsValid(string $behavior): bool
+    {
+        return in_array($behavior, [self::CLOSE_BEHAVIOR_HIDE, self::CLOSE_BEHAVIOR_MARK_DISMISSED], true);
     }
 }

--- a/src/DataTransferObjects/NoticeElementProperties.php
+++ b/src/DataTransferObjects/NoticeElementProperties.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace StellarWP\AdminNotices\DataTransferObjects;
+
+use StellarWP\AdminNotices\AdminNotice;
+
+class NoticeElementProperties
+{
+    /**
+     * @var string
+     */
+    public $idAttribute;
+
+    /**
+     * @var string
+     */
+    public $closerIdentifierClass;
+
+    /**
+     * @var string
+     */
+    public $closerHideClass;
+
+    /**
+     * @var string[]
+     */
+    public $closerClasses;
+
+    /**
+     * @var string
+     */
+    public $customNoticeClass;
+
+    /**
+     * @var string
+     */
+    public $customLocationClass;
+
+    /**
+     * @var string
+     */
+    public $customLocationAttribute;
+
+    public function __construct(AdminNotice $notice, string $namespace)
+    {
+        $this->idAttribute = "data-stellarwp-$namespace-notice-id='{$notice->getId()}'";
+        $this->closerIdentifierClass = "js-stellarwp-$namespace-close-notice";
+        $this->closerHideClass = "js-stellarwp-$namespace-close-notice--hide";
+
+        $this->customNoticeClass = "stellarwp-$namespace-notice-custom";
+        $this->customLocationClass = "stellarwp-$namespace-location-{$notice->getLocation()}";
+        $this->customLocationAttribute = "data-stellarwp-$namespace-location='{$notice->getLocation()}'";
+
+        $this->closerClasses = $notice->isDismissible() ? [
+            $this->closerIdentifierClass,
+            $this->closerHideClass,
+        ] : [];
+    }
+}

--- a/src/DataTransferObjects/NoticeElementProperties.php
+++ b/src/DataTransferObjects/NoticeElementProperties.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace StellarWP\AdminNotices\DataTransferObjects;
 
+use InvalidArgumentException;
 use StellarWP\AdminNotices\AdminNotice;
 
 class NoticeElementProperties
@@ -12,51 +13,65 @@ class NoticeElementProperties
     /**
      * @var string
      */
+    private $namespace;
+
+    /**
+     * @var string
+     */
     public $idAttribute;
 
-    /**
-     * @var string
-     */
-    public $closerIdentifierClass;
-
-    /**
-     * @var string
-     */
-    public $closerHideClass;
-
-    /**
-     * @var string[]
-     */
-    public $closerClasses;
-
-    /**
-     * @var string
-     */
-    public $customNoticeClass;
-
-    /**
-     * @var string
-     */
-    public $customLocationClass;
+    public $customCloserAttribute;
 
     /**
      * @var string
      */
     public $customLocationAttribute;
 
+    /**
+     * @var string
+     */
+    public $customWrapperAttributes;
+
+    /**
+     * @unreleased
+     */
     public function __construct(AdminNotice $notice, string $namespace)
     {
+        $this->namespace = $namespace;
+
         $this->idAttribute = "data-stellarwp-$namespace-notice-id='{$notice->getId()}'";
-        $this->closerIdentifierClass = "js-stellarwp-$namespace-close-notice";
-        $this->closerHideClass = "js-stellarwp-$namespace-close-notice--hide";
 
-        $this->customNoticeClass = "stellarwp-$namespace-notice-custom";
-        $this->customLocationClass = "stellarwp-$namespace-location-{$notice->getLocation()}";
         $this->customLocationAttribute = "data-stellarwp-$namespace-location='{$notice->getLocation()}'";
+        $this->customWrapperAttributes = "$this->idAttribute $this->customLocationAttribute";
 
-        $this->closerClasses = $notice->isDismissible() ? [
-            $this->closerIdentifierClass,
-            $this->closerHideClass,
-        ] : [];
+        $this->customCloserAttribute = "data-stellarwp-$namespace-close-notice='{$notice->getId()}'";
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param 'hide'|'clear' $behavior
+     */
+    public function customCloseBehaviorAttribute(string $behavior = 'hide'): string
+    {
+        if (!in_array($behavior, ['hide', 'clear'], true)) {
+            throw new InvalidArgumentException('Invalid behavior for custom closer attribute.');
+        }
+
+        return "data-stellarwp-{$this->namespace}-close-notice-behavior='$behavior'";
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param 'hide'|'clear' $behavior
+     */
+    public function customCloserAttributes(string $behavior = 'hide'): string
+    {
+        if (!in_array($behavior, ['hide', 'clear'], true)) {
+            throw new InvalidArgumentException('Invalid behavior for custom closer attribute.');
+        }
+
+        return "$this->customCloserAttribute {$this->customCloseBehaviorAttribute($behavior)}";
     }
 }

--- a/src/ValueObjects/NoticeLocation.php
+++ b/src/ValueObjects/NoticeLocation.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace StellarWP\AdminNotices\ValueObjects;
+
+use InvalidArgumentException;
+
+class NoticeLocation
+{
+    /**
+     * @var string
+     */
+    private $location;
+
+    /**
+     * @unreleased
+     */
+    public static function aboveHeader(): self
+    {
+        return new self('above_header');
+    }
+
+    /**
+     * An alias of aboveHeader(), as this is the standard WordPress location for admin notices.
+     *
+     * @unreleased
+     */
+    public static function standard(): self
+    {
+        return self::belowHeader();
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function belowHeader(): self
+    {
+        return new self('below_header');
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function inline(): self
+    {
+        return new self('inline');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __construct(string $location)
+    {
+        $this->validateLocation($location);
+
+        $this->location = $location;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __toString()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function isAboveHeader(): bool
+    {
+        return $this->location === 'above_header';
+    }
+
+    /**
+     * @unreleased
+     */
+    public function isBelowHeader(): bool
+    {
+        return $this->location === 'below_header';
+    }
+
+    /**
+     * An alias of isAboveHeader(), as this is the standard WordPress location for admin notices.
+     *
+     * @unreleased
+     */
+    public function isStandard(): bool
+    {
+        return $this->isBelowHeader();
+    }
+
+    /**
+     * @unreleased
+     */
+    public function isInline(): bool
+    {
+        return $this->location === 'inline';
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param string|self $location
+     */
+    public function equals($location): bool
+    {
+        if (!(is_string($location) || $location instanceof self)) {
+            throw new InvalidArgumentException(
+                'Invalid location: ' . gettype($location) . ' - must be a string or an instance of ' . self::class
+            );
+        }
+
+        return $location instanceof self
+            ? $this->location === $location->location
+            : $this->location === $location;
+    }
+
+    /**
+     * @unreleased
+     */
+    private function validateLocation(string $location)
+    {
+        $validLocations = [
+            'above_header',
+            'below_header',
+            'inline',
+        ];
+
+        if (!in_array($location, $validLocations, true)) {
+            throw new InvalidArgumentException(
+                "Invalid location: $location - must be one of " . implode(', ', $validLocations)
+            );
+        }
+    }
+}

--- a/src/ValueObjects/NoticeLocation.php
+++ b/src/ValueObjects/NoticeLocation.php
@@ -9,6 +9,10 @@ use InvalidArgumentException;
 
 class NoticeLocation
 {
+    private const ABOVE_HEADER = 'above_header';
+    private const BELOW_HEADER = 'below_header';
+    private const INLINE = 'inline';
+
     /**
      * @var string
      */
@@ -19,7 +23,7 @@ class NoticeLocation
      */
     public static function aboveHeader(): self
     {
-        return new self('above_header');
+        return new self(self::ABOVE_HEADER);
     }
 
     /**
@@ -37,7 +41,7 @@ class NoticeLocation
      */
     public static function belowHeader(): self
     {
-        return new self('below_header');
+        return new self(self::BELOW_HEADER);
     }
 
     /**
@@ -45,7 +49,7 @@ class NoticeLocation
      */
     public static function inline(): self
     {
-        return new self('inline');
+        return new self(self::INLINE);
     }
 
     /**
@@ -71,7 +75,7 @@ class NoticeLocation
      */
     public function isAboveHeader(): bool
     {
-        return $this->location === 'above_header';
+        return $this->location === self::ABOVE_HEADER;
     }
 
     /**
@@ -79,7 +83,7 @@ class NoticeLocation
      */
     public function isBelowHeader(): bool
     {
-        return $this->location === 'below_header';
+        return $this->location === self::BELOW_HEADER;
     }
 
     /**
@@ -97,7 +101,7 @@ class NoticeLocation
      */
     public function isInline(): bool
     {
-        return $this->location === 'inline';
+        return $this->location === self::INLINE;
     }
 
     /**
@@ -124,9 +128,9 @@ class NoticeLocation
     private function validateLocation(string $location)
     {
         $validLocations = [
-            'above_header',
-            'below_header',
-            'inline',
+            self::ABOVE_HEADER,
+            self::BELOW_HEADER,
+            self::INLINE,
         ];
 
         if (!in_array($location, $validLocations, true)) {

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -25,26 +25,36 @@
     };
 
     // Begin notice dismissal code
-    const noticeIdAttribute = `data-stellarwp-${namespace}-notice-id`;
-    const $notices = $(`[${noticeIdAttribute}]`);
+    const noticeIdAttribute = `stellarwp-${namespace}-notice-id`;
+    const dataNoticeIdAttribute = `data-${noticeIdAttribute}`;
+    const $notices = $(`[${dataNoticeIdAttribute}]`);
 
     // Mark standard notices as closed
     $notices.on('click', '.notice-dismiss', function () {
         const $this = $(this);
-        const noticeId = $this.closest(`[${noticeIdAttribute}]`).data(`stellarwp-${namespace}-notice-id`);
+        const noticeId = $this.closest(`[${dataNoticeIdAttribute}]`).data(`stellarwp-${namespace}-notice-id`);
 
         window.stellarwp.adminNotices[namespace].dismissNotice(noticeId);
     });
 
     // Mark and close custom notice closes
-    $notices.on('click', `.js-stellarwp-${namespace}-close-notice`, function () {
+    const closeAttribute = `stellarwp-${namespace}-close-notice`;
+    const dataCloseAttribute = `data-${closeAttribute}`;
+    const closeBehaviorAttribute = `stellarwp-${namespace}-close-notice-behavior`;
+
+    $(`[${dataCloseAttribute}]`).on('click', function () {
         const $this = $(this);
-        const $notice = $this.closest(`[${noticeIdAttribute}]`);
-        const noticeId = $notice.data(`stellarwp-${namespace}-notice-id`);
+        const noticeId = $this.data(closeAttribute);
+        const $notice = $(`[${dataNoticeIdAttribute}="${noticeId}"]`);
+
+        if (!$notice.length) {
+            console.log(`Unable to find and close notice with ID: ${noticeId}`);
+            return;
+        }
 
         window.stellarwp.adminNotices[namespace].dismissNotice(noticeId);
 
-        if ($this.hasClass(`js-stellarwp-${namespace}-close-notice--hide`)) {
+        if ($this.data(closeBehaviorAttribute) === 'hide') {
             $notice.fadeOut();
         }
     });

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -28,9 +28,41 @@
     const noticeIdAttribute = `data-stellarwp-${namespace}-notice-id`;
     const $notices = $(`[${noticeIdAttribute}]`);
 
-    $notices.on('click', '.notice-dismiss', function (event) {
-        const noticeId = $(this).closest(`[${noticeIdAttribute}]`).data(`stellarwp-${namespace}-notice-id`);
+    // Mark standard notices as closed
+    $notices.on('click', '.notice-dismiss', function () {
+        const $this = $(this);
+        const noticeId = $this.closest(`[${noticeIdAttribute}]`).data(`stellarwp-${namespace}-notice-id`);
 
         window.stellarwp.adminNotices[namespace].dismissNotice(noticeId);
+    });
+
+    // Mark and close custom notice closes
+    $notices.on('click', `.js-stellarwp-${namespace}-close-notice`, function () {
+        const $this = $(this);
+        const $notice = $this.closest(`[${noticeIdAttribute}]`);
+        const noticeId = $notice.data(`stellarwp-${namespace}-notice-id`);
+
+        window.stellarwp.adminNotices[namespace].dismissNotice(noticeId);
+
+        if ($this.hasClass(`js-stellarwp-${namespace}-close-notice--hide`)) {
+            $notice.fadeOut();
+        }
+    });
+
+    // Position custom notices
+    const locationAttribute = `stellarwp-${namespace}-location`;
+    const dataLocationAttribute = `data-${locationAttribute}`;
+
+    $(`[${dataLocationAttribute}]`).each(function () {
+        const $notice = $(this);
+        const location = $notice.data(locationAttribute);
+
+        if (location === 'below_header') {
+            $notice.insertAfter('h1');
+        } else if (location === 'above_header') {
+            $notice.insertBefore('h1');
+        } else if (location === 'inline') {
+            $notice.insertBefore('#wpdoby-content > .wrap');
+        }
     });
 })(window.jQuery, window.wp.data.dispatch, document);

--- a/tests/_support/Traits/WithUopz.php
+++ b/tests/_support/Traits/WithUopz.php
@@ -2,213 +2,605 @@
 
 namespace StellarWP\AdminNotices\Tests\Support\Traits;
 
+use Closure;
+
 trait WithUopz
 {
-    /*
-     * The following properties are static to cover data providers where 2 diff. instances of the test case are used:
-     * one to build the data sets, the other to run the tests.
+    /**
+     * @var array<string,bool>
      */
-    private static $uopz_set_returns = [];
-    private static $uopz_redefines = [];
-    private static $uopz_set_properties = [];
-    private static $uopz_add_class_fns = [];
-    private static $uopz_del_functions = [];
+    private static $uopzSetFunctionReturns = [];
 
     /**
-     * @after
+     * @var array<string,bool>
      */
-    public function unset_uopz_returns()
-    {
-        if (function_exists('uopz_set_return')) {
-            foreach (self::$uopz_set_returns as $f) {
-                if (is_array($f)) {
-                    [$class, $method] = $f;
-                    uopz_unset_return($class, $method);
-                } else {
-                    uopz_unset_return($f);
-                }
-            }
-        }
-
-        self::$uopz_set_returns = [];
-    }
+    private static $uopzSetFunctionHooks = [];
 
     /**
-     * @after
+     * @var array<string,mixed>
      */
-    public function unset_uopz_redefines()
-    {
-        if (function_exists('uopz_redefine')) {
-            foreach (self::$uopz_redefines as $restore_callback) {
-                $restore_callback();
-            }
-        }
-
-        self::$uopz_redefines = [];
-    }
+    private static $uopzSetConstants = [];
 
     /**
-     * @after
+     * @var array<string,bool>
      */
-    public function unset_uopz_properties()
-    {
-        if (function_exists('uopz_set_property')) {
-            foreach (self::$uopz_set_properties as $definition) {
-                [$object, $field, $original_value] = $definition;
-                // Overwrite value with what we stored as the original value.
-                uopz_set_property($object, $field, $original_value);
-            }
-        }
-        self::$uopz_set_properties = [];
-    }
+    private static $uopzSetClassMocks = [];
 
     /**
-     * @after
+     * @var array<string,bool>
      */
-    public function unset_uopz_functions()
-    {
-        if (function_exists('uopz_del_function')) {
-            foreach (self::$uopz_del_functions as $function) {
-                uopz_del_function($function);
-            }
-        }
-
-        self::$uopz_del_functions = [];
-    }
+    private static $uopzUnsetClassFinalAttribute = [];
 
     /**
-     * Wrapper for uopz_set_return
-     *
-     * @param [type] $fn       The name of an existing function
-     * @param [type] $value    The value the function should return.
-     *                         If a Closure is provided and the execute flag is set,
-     *                         the Closure will be executed in place of the original function.
-     * @param boolean $execute If true, and a Closure was provided as the value,
-     *                         the Closure will be executed in place of the original function.
-     *
-     * @return void
+     * @var array<string,bool>
      */
-    private function set_fn_return($fn, $value, $execute = false)
+    private static $uopzAddClassMethods = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private static $uopzUnsetClassMethodFinalAttribute = [];
+
+    /**
+     * @var array<string,mixed>
+     */
+    private static $uopzSetObjectProperties = [];
+
+    /**
+     * @var array<string,array<string,mixed>>
+     */
+    private static $uopzSetMethodStaticVariables = [];
+
+    /**
+     * @var array<string,array<string,mixed>>
+     */
+    private static $uopzSetFunctionStaticVariables = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private static $uopzAddedFunctions = [];
+
+    /**
+     * @var bool|null
+     */
+    private static $uopzAllowExit;
+
+    /**
+     * @param mixed $value
+     */
+    protected function setFunctionReturn(string $function, $value, bool $execute = false): Closure
     {
         if (!function_exists('uopz_set_return')) {
-            $this->markTestSkipped('uopz extension is not installed');
+            $this->markTestSkipped('This test requires the uopz extension');
         }
-        uopz_set_return($fn, $value, $execute);
-        self::$uopz_set_returns[] = $fn;
+
+        uopz_set_return($function, $value, $execute);
+        self::$uopzSetFunctionReturns[$function] = true;
+
+        return function () use ($function) {
+            $this->unsetFunctionReturn($function);
+        };
     }
 
-    private function set_const_value($const, ...$args)
+    protected function unsetFunctionReturn(string $function): void
     {
-        if (!function_exists('uopz_redefine')) {
-            $this->markTestSkipped('uopz extension is not installed');
-        }
-
-        if (count($args) === 1) {
-            // Normal const redefinition.
-            $previous_value = defined($const) ? constant($const) : null;
-            if (null === $previous_value) {
-                $restore_callback = static function () use ($const) {
-                    uopz_undefine($const);
-                    Assert::assertFalse(defined($const));
-                };
-            } else {
-                $restore_callback = static function () use ($previous_value, $const) {
-                    uopz_redefine($const, $previous_value);
-                    Assert::assertEquals($previous_value, constant($const));
-                };
-            }
-            uopz_redefine($const, $args[0]);
-            self::$uopz_redefines[] = $restore_callback;
-
+        if (!isset(self::$uopzSetFunctionReturns[$function])) {
             return;
         }
 
-        // Static class const redefinition.
-        $class = $const;
-        [$const, $value] = $args;
-        $previous_value = defined($class . '::' . $const) ?
-            constant($class . '::' . $const)
-            : null;
-
-        if (null === $previous_value) {
-            $restore_callback = static function () use ($const, $class) {
-                uopz_undefine($class, $const);
-                Assert::assertFalse(defined($class . '::' . $const));
-            };
-        } else {
-            $restore_callback = static function () use ($class, $const, $previous_value) {
-                uopz_redefine($class, $const, $previous_value);
-                Assert::assertEquals($previous_value, constant($class . '::' . $const));
-            };
-        }
-        uopz_redefine($const, ...$args);
-        self::$uopz_redefines[] = $restore_callback;
-    }
-
-    private function set_class_fn_return($class, $method, $value, $execute = false)
-    {
-        if (!function_exists('uopz_set_return')) {
-            $this->markTestSkipped('uopz extension is not installed');
-        }
-        uopz_set_return($class, $method, $value, $execute);
-        self::$uopz_set_returns[] = [$class, $method];
+        uopz_unset_return($function);
+        unset(self::$uopzSetFunctionReturns[$function]);
     }
 
     /**
-     * @param $object
-     * @param $field
-     * @param $value
+     * @param mixed $value
      */
-    private function set_class_property($object, $field, $value)
+    protected function setMethodReturn(string $class, string $method, $value, bool $execute = false): Closure
     {
-        if (!function_exists('uopz_set_property')) {
-            $this->markTestSkipped('uopz extension is not installed');
-        }
-        $original_value = uopz_get_property($object, $field);
-        uopz_set_property($object, $field, $value);
-        // Store here to override, i.e. unset, later.
-        self::$uopz_set_properties[] = [$object, $field, $original_value];
+        $classAndMethod = "$class::$method";
+        uopz_set_return($class, $method, $value, $execute);
+        self::$uopzSetFunctionReturns[$classAndMethod] = true;
+
+        return function () use ($class, $method) {
+            $this->unsetMethodReturn($class, $method);
+        };
     }
 
-    private function add_class_fn($class, $function, $handler)
+    protected function unsetMethodReturn(string $class, string $method): void
+    {
+        $classAndMethod = "$class::$method";
+
+        if (!isset(self::$uopzSetFunctionReturns[$classAndMethod])) {
+            return;
+        }
+
+        uopz_unset_return($class, $method);
+        unset(self::$uopzSetFunctionReturns[$classAndMethod]);
+    }
+
+    protected function setFunctionHook(string $function, Closure $hook): Closure
+    {
+        if (!function_exists('uopz_set_hook')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        uopz_set_hook($function, $hook);
+        self::$uopzSetFunctionHooks[$function] = true;
+
+        return function () use ($function) {
+            $this->unsetFunctionHook($function);
+        };
+    }
+
+    protected function unsetFunctionHook(string $function): void
+    {
+        if (!isset(self::$uopzSetFunctionHooks[$function])) {
+            return;
+        }
+
+        uopz_unset_hook($function);
+        unset(self::$uopzSetFunctionHooks[$function]);
+    }
+
+    protected function setMethodHook(string $class, string $method, Closure $hook): Closure
+    {
+        if (!function_exists('uopz_set_hook')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $classAndMethod = "$class::$method";
+        uopz_set_hook($class, $method, $hook);
+        self::$uopzSetFunctionHooks[$classAndMethod] = true;
+
+        return function () use ($class, $method) {
+            $this->unsetMethodHook($class, $method);
+        };
+    }
+
+    protected function unsetMethodHook(string $class, string $method): void
+    {
+        $classAndMethod = "$class::$method";
+
+        if (!isset(self::$uopzSetFunctionHooks[$classAndMethod])) {
+            return;
+        }
+
+        uopz_unset_hook($class, $method);
+        unset(self::$uopzSetFunctionHooks[$classAndMethod]);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function setConstant(string $constant, $value): Closure
+    {
+        if (!function_exists('uopz_redefine')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $previousValue = defined($constant) ? constant($constant) : '__NOT_PREVIOUSLY_DEFINED__';
+        if ($previousValue === '__NOT_PREVIOUSLY_DEFINED__') {
+            define($constant, $value);
+        } else {
+            uopz_redefine($constant, $value);
+        }
+        self::$uopzSetConstants[$constant] = $previousValue;
+
+        return function () use ($constant) {
+            $this->unsetConstant($constant);
+        };
+    }
+
+    protected function unsetConstant(string $constant): void
+    {
+        if (!isset(self::$uopzSetConstants[$constant])) {
+            return;
+        }
+
+        $previousValue = self::$uopzSetConstants[$constant];
+
+        if ($previousValue !== '__NOT_PREVIOUSLY_DEFINED__') {
+            uopz_redefine($constant, $previousValue);
+        } else {
+            uopz_undefine($constant);
+        }
+        unset(self::$uopzSetConstants[$constant]);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function setClassConstant(string $class, string $constant, $value): Closure
+    {
+        if (!function_exists('uopz_redefine')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $previousValue = defined("$class::$constant") ?
+            constant("$class::$constant")
+            : '__NOT_PREVIOUSLY_DEFINED__';
+        uopz_redefine($class, $constant, $value);
+        self::$uopzSetConstants["$class::$constant"] = $previousValue;
+
+        return function () use ($class, $constant) {
+            $this->unsetClassConstant($class, $constant);
+        };
+    }
+
+    protected function unsetClassConstant(string $class, string $constant): void
+    {
+        if (!isset(self::$uopzSetConstants["$class::$constant"])) {
+            return;
+        }
+
+        $previousValue = self::$uopzSetConstants["$class::$constant"];
+
+        if ($previousValue !== '__NOT_PREVIOUSLY_DEFINED__') {
+            uopz_redefine($class, $constant, $previousValue);
+        } else {
+            uopz_undefine($class, $constant);
+        }
+        unset(self::$uopzSetConstants["$class::$constant"]);
+    }
+
+    /**
+     * @param mixed $mock
+     */
+    protected function setClassMock(string $class, $mock): Closure
+    {
+        if (!function_exists('uopz_set_mock')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        uopz_set_mock($class, $mock);
+        self::$uopzSetClassMocks[$class] = true;
+
+        return function () use ($class) {
+            $this->unsetClassMock($class);
+        };
+    }
+
+    protected function unsetClassMock(string $class): void
+    {
+        if (!isset(self::$uopzSetClassMocks[$class])) {
+            return;
+        }
+
+        uopz_unset_mock($class);
+        unset(self::$uopzSetClassMocks[$class]);
+    }
+
+    protected function unsetClassFinalAttribute(string $class): Closure
+    {
+        if (!function_exists('uopz_unset_return')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $flags = uopz_flags($class, '');
+        uopz_flags($class, '', $flags & ~ZEND_ACC_FINAL);
+        self::$uopzUnsetClassFinalAttribute[$class] = true;
+
+        return function () use ($class) {
+            $this->resetClassFinalAttribute($class);
+        };
+    }
+
+    protected function resetClassFinalAttribute(string $class): void
+    {
+        if (!isset(self::$uopzUnsetClassFinalAttribute[$class])) {
+            return;
+        }
+
+        $flags = uopz_flags($class, '');
+        uopz_flags($class, '', $flags | ZEND_ACC_FINAL);
+        unset(self::$uopzUnsetClassFinalAttribute[$class]);
+    }
+
+    protected function unsetMethodFinalAttribute(string $class, string $method): Closure
+    {
+        if (!function_exists('uopz_unset_return')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $flags = uopz_flags($class, $method);
+        uopz_flags($class, $method, $flags & ~ZEND_ACC_FINAL);
+        self::$uopzUnsetClassMethodFinalAttribute["$class::$method"] = true;
+
+        return function () use ($class, $method) {
+            $this->resetMethodFinalAttribute($class, $method);
+        };
+    }
+
+    protected function resetMethodFinalAttribute(string $class, string $method): void
+    {
+        $classAndMethod = "$class::$method";
+        if (!isset(self::$uopzUnsetClassMethodFinalAttribute[$classAndMethod])) {
+            return;
+        }
+
+        $flags = uopz_flags($class, $method);
+        uopz_flags($class, $method, $flags | ZEND_ACC_FINAL);
+        unset(self::$uopzUnsetClassMethodFinalAttribute[$classAndMethod]);
+    }
+
+    protected function addClassMethod(string $class, string $method, Closure $closure, bool $static = false): Closure
     {
         if (!function_exists('uopz_add_function')) {
-            $this->markTestSkipped('uopz extension is not installed');
+            $this->markTestSkipped('This test requires the uopz extension');
         }
-        uopz_add_function(
-            $class,
-            $function,
-            $handler
-        );
-        self::$uopz_add_class_fns[] = [$class, $function];
+
+        $flags = ZEND_ACC_PUBLIC;
+        if ($static) {
+            $flags |= ZEND_ACC_STATIC;
+        }
+        uopz_add_function($class, $method, $closure, $flags);
+        self::$uopzAddClassMethods["$class::$method"] = true;
+
+        return function () use ($class, $method) {
+            $this->removeClassMethod($class, $method);
+        };
+    }
+
+    protected function removeClassMethod(string $class, string $method): void
+    {
+        $classAndMethod = "$class::$method";
+        if (!isset(self::$uopzAddClassMethods[$classAndMethod])) {
+            return;
+        }
+
+        uopz_del_function($class, $method);
+        unset(self::$uopzAddClassMethods[$classAndMethod]);
+    }
+
+    /**
+     * @param string|object $classOrObject
+     * @param mixed $value
+     */
+    protected function setObjectProperty(
+        $classOrObject,
+        string $property,
+        $value
+    ): Closure {
+        if (!function_exists('uopz_set_property')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $previousValue = uopz_get_property($classOrObject, $property);
+        uopz_set_property($classOrObject, $property, $value);
+        $id = is_string($classOrObject) ? $classOrObject : spl_object_hash($classOrObject);
+        self::$uopzSetObjectProperties["$id::$property"] = [$previousValue, $classOrObject];
+
+        return function () use ($classOrObject, $property) {
+            $this->resetObjectProperty($classOrObject, $property);
+        };
+    }
+
+    /**
+     * @param string|object $classOrObject
+     *
+     * @return mixed
+     */
+    protected function getObjectProperty($classOrObject, string $property)
+    {
+        if (!function_exists('uopz_get_property')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        return uopz_get_property($classOrObject, $property);
+    }
+
+    /**
+     * @param string|object $classOrObject
+     */
+    protected function resetObjectProperty($classOrObject, string $property): void
+    {
+        $id = is_string($classOrObject) ? $classOrObject : spl_object_hash($classOrObject);
+
+        if (!isset(self::$uopzSetObjectProperties["$id::$property"])) {
+            return;
+        }
+
+        [$previousValue, $classOrObject] = self::$uopzSetObjectProperties["$id::$property"];
+        uopz_set_property($classOrObject, $property, $previousValue);
+        unset(self::$uopzSetObjectProperties["$id::$property"]);
+    }
+
+    /**
+     * @param array<string,mixed> $values
+     */
+    protected function setMethodStaticVariables(string $class, string $method, array $values): Closure
+    {
+        if (!function_exists('uopz_set_static')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $currentValues = uopz_get_static($class, $method);
+        $currentValues['__CLONE__'] = '__CLONE__';
+        unset($currentValues['__CLONE__']);
+
+        if (!isset(self::$uopzSetMethodStaticVariables["$class::$method"])) {
+            self::$uopzSetMethodStaticVariables["$class::$method"] = $currentValues;
+        }
+
+        uopz_set_static($class, $method, $values);
+
+        return function () use ($class, $method) {
+            $this->resetMethodStaticVariables($class, $method);
+        };
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getMethodStaticVariables(string $class, string $method): array
+    {
+        if (!function_exists('uopz_get_static')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $currentValues = uopz_get_static($class, $method);
+        $currentValues['__CLONE__'] = '__CLONE__';
+        unset($currentValues['__CLONE__']);
+
+        return $currentValues;
+    }
+
+    protected function resetMethodStaticVariables(string $class, string $method): void
+    {
+        if (!isset(self::$uopzSetMethodStaticVariables["$class::$method"])) {
+            return;
+        }
+
+        $staticVariables = self::$uopzSetMethodStaticVariables["$class::$method"];
+        uopz_set_static($class, $method, $staticVariables);
+        unset(self::$uopzSetMethodStaticVariables["$class::$method"]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getFunctionStaticVariables(string $function): array
+    {
+        if (!function_exists('uopz_get_static')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $currentValues = uopz_get_static($function);
+        $currentValues['__CLONE__'] = '__CLONE__';
+        unset($currentValues['__CLONE__']);
+
+        return $currentValues;
+    }
+
+    /**
+     * @param array<string,mixed> $values
+     */
+    protected function setFunctionStaticVariables(string $function, array $values): Closure
+    {
+        if (!function_exists('uopz_set_static')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        $currentValues = uopz_get_static($function);
+        $currentValues['__CLONE__'] = '__CLONE__';
+        unset($currentValues['__CLONE__']);
+
+        if (!isset(self::$uopzSetFunctionStaticVariables[$function])) {
+            self::$uopzSetFunctionStaticVariables[$function] = $currentValues;
+        }
+
+        uopz_set_static($function, array_merge($currentValues, $values));
+
+        return function () use ($function) {
+            $this->resetFunctionStaticVariables($function);
+        };
+    }
+
+    protected function resetFunctionStaticVariables(string $function): void
+    {
+        if (!isset(self::$uopzSetFunctionStaticVariables[$function])) {
+            return;
+        }
+
+        $staticVariables = self::$uopzSetFunctionStaticVariables[$function];
+        uopz_set_static($function, $staticVariables);
+        unset(self::$uopzSetFunctionStaticVariables[$function]);
+    }
+
+    protected function addFunction(string $function, Closure $handler): Closure
+    {
+        if (!function_exists('uopz_add_function')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        self::$uopzAddedFunctions[$function] = true;
+        uopz_add_function($function, $handler);
+
+        return function () use ($function) {
+            $this->removeFunction($function);
+        };
+    }
+
+    protected function removeFunction(string $function): void
+    {
+        if (!function_exists('uopz_del_function')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        if (!isset(self::$uopzAddedFunctions[$function])) {
+            return;
+        }
+
+        uopz_del_function($function);
+        unset(self::$uopzAddedFunctions[$function]);
+    }
+
+    protected function preventExit(): void
+    {
+        if (!function_exists('uopz_allow_exit')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        uopz_allow_exit(false);
+        self::$uopzAllowExit = false;
+    }
+
+    protected function allowExit(): void
+    {
+        if (self::$uopzAllowExit === true) {
+            return;
+        }
+
+        if (!function_exists('uopz_allow_exit')) {
+            $this->markTestSkipped('This test requires the uopz extension');
+        }
+
+        uopz_allow_exit(true);
+        self::$uopzAllowExit = true;
     }
 
     /**
      * @after
      */
-    public function undefine_uopz_class_fn()
+    public function resetUopzAlterations(): void
     {
-        if (!function_exists('uopz_del_function')) {
-            $this->markTestSkipped('uopz extension is not installed');
+        foreach (self::$uopzSetFunctionReturns as $function => $k) {
+            if (strpos($function, '::') !== false) {
+                $this->unsetMethodReturn(...explode('::', $function));
+            } else {
+                $this->unsetFunctionReturn($function);
+            }
         }
 
-        foreach (self::$uopz_add_class_fns as $definition) {
-            [$class, $function] = $definition;
-            uopz_del_function($class, $function);
+        foreach (self::$uopzSetFunctionHooks as $function => $k) {
+            $this->unsetFunctionHook($function);
         }
-        self::$uopz_add_class_fns = [];
-    }
 
-    /**
-     * @param string $function
-     * @param \Closure $handler
-     */
-    private function add_fn(string $function, \Closure $handler)
-    {
-        if (!function_exists('uopz_add_function')) {
-            $this->markTestSkipped('uopz extension is not installed');
+        foreach (self::$uopzSetConstants as $constant => $k) {
+            $this->unsetConstant($constant);
         }
-        uopz_add_function($function, $handler);
-        self::$uopz_del_functions[] = $function;
+
+        foreach (self::$uopzSetClassMocks as $class => $k) {
+            $this->unsetClassMock($class);
+        }
+
+        foreach (self::$uopzSetObjectProperties as $idAndProperty => [$previousValue, $classOrObject]) {
+            [, $property] = explode('::', $idAndProperty);
+            $this->resetObjectProperty($classOrObject, $property);
+        }
+
+        foreach (self::$uopzSetMethodStaticVariables as $classAndMethod => $values) {
+            [$class, $method] = explode('::', $classAndMethod);
+            $this->resetMethodStaticVariables($class, $method);
+        }
+
+        foreach (self::$uopzSetFunctionStaticVariables as $function => $values) {
+            $this->resetFunctionStaticVariables($function);
+        }
+
+        foreach (self::$uopzAddedFunctions as $function => $k) {
+            $this->removeFunction($function);
+        }
     }
 }

--- a/tests/unit/Actions/DisplayNoticesInAdminTest.php
+++ b/tests/unit/Actions/DisplayNoticesInAdminTest.php
@@ -58,7 +58,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $notice1 = $this->getSimpleMockNotice('foo');
         $notice2 = $this->getSimpleMockNotice('bar');
 
-        $this->expectOutputString('foobar');
+        $this->expectOutputString($this->getSimpleNoticeOutput('foo') . $this->getSimpleNoticeOutput('bar'));
         $displayNoticesInAdmin($notice1, $notice2);
     }
 
@@ -73,7 +73,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         if ($shouldPass) {
-            $this->expectOutputString('foo');
+            $this->expectNoticeInOutput('foo');
         } else {
             $this->expectOutputString('');
         }
@@ -111,7 +111,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         if ($shouldPass) {
-            $this->expectOutputString('foo');
+            $this->expectNoticeInOutput('foo');
         } else {
             $this->expectOutputString('');
         }
@@ -152,7 +152,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
 
         if ($shouldPass) {
-            $this->expectOutputString('foo');
+            $this->expectNoticeInOutput('foo');
         } else {
             $this->expectOutputString('');
         }
@@ -198,7 +198,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo');
 
-        $this->expectOutputString('foo');
+        $this->expectNoticeInOutput('foo');
         $displayNoticesInAdmin($notice);
     }
 
@@ -209,7 +209,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo')->on('~Dashboard~i'); // check regex flags, too
 
-        $this->expectOutputString('foo');
+        $this->expectNoticeInOutput('foo');
         $displayNoticesInAdmin($notice);
     }
 
@@ -220,7 +220,7 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo')->on('dashboard');
 
-        $this->expectOutputString('foo');
+        $this->expectNoticeInOutput('foo');
         $displayNoticesInAdmin($notice);
     }
 
@@ -234,8 +234,24 @@ class DisplayNoticesInAdminTest extends TestCase
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');
         $notice = $this->getSimpleMockNotice('foo')->on(['base' => 'dashboard']);
 
-        $this->expectOutputString('foo');
+        $this->expectNoticeInOutput('foo');
         $displayNoticesInAdmin($notice);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function expectNoticeInOutput(string $expected): void
+    {
+        $this->expectOutputString($this->getSimpleNoticeOutput($expected));
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getSimpleNoticeOutput(string $content): string
+    {
+        return "<div class='notice notice-info' data-stellarwp-namespace-notice-id='test_id'>$content</div>";
     }
 
     /**
@@ -246,7 +262,6 @@ class DisplayNoticesInAdminTest extends TestCase
     private function getSimpleMockNotice($output): AdminNotice
     {
         return (new AdminNotice('test_id', $output))
-            ->withoutWrapper()
             ->withoutAutoParagraph();
     }
 }

--- a/tests/unit/Actions/DisplayNoticesInAdminTest.php
+++ b/tests/unit/Actions/DisplayNoticesInAdminTest.php
@@ -228,7 +228,7 @@ class DisplayNoticesInAdminTest extends TestCase
     {
         $_SERVER['REQUEST_URI'] = 'http://example.com/wp-admin/dashboard.php';
 
-        $this->set_fn_return('get_current_screen', (object)['base' => 'dashboard']);
+        $this->setFunctionReturn('get_current_screen', (object)['base' => 'dashboard']);
 
         // mock get_current_screen() global function
         $displayNoticesInAdmin = new DisplayNoticesInAdmin('namespace');

--- a/tests/unit/Actions/RenderAdminNoticeTest.php
+++ b/tests/unit/Actions/RenderAdminNoticeTest.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
+use lucatume\WPBrowser\Traits\UopzFunctions;
 use StellarWP\AdminNotices\Actions\RenderAdminNotice;
 use StellarWP\AdminNotices\AdminNotice;
 use StellarWP\AdminNotices\Tests\Support\Helper\TestCase;
 
 class RenderAdminNoticeTest extends TestCase
 {
+    use UopzFunctions;
+
     /**
      * @since 1.0.0
      */
@@ -95,5 +98,100 @@ class RenderAdminNoticeTest extends TestCase
             "<div class='notice notice-info' data-stellarwp-namespace-notice-id='test_id'>Hello world!</div>",
             $renderAdminNotice($notice)
         );
+    }
+
+    public function testShouldIncludeAttributesForCustomNotices()
+    {
+        $notice = (new AdminNotice('test_id', function () {
+            return '<div>It is Stellar at StellarWP</div>';
+        }))
+            ->custom();
+        $expectedNoticeWithAttributes = "<div data-stellarwp-namespace-notice-id='test_id' data-stellarwp-namespace-location='below_header'>It is Stellar at StellarWP</div>";
+
+        $renderAdminNotice = new RenderAdminNotice('namespace');
+
+        $tagProcessorMock = $this->createMock(TagProcessorMock::class);
+
+        $tagMatcher = $this->exactly(2);
+        $tagProcessorMock
+            ->expects($tagMatcher)
+            ->method('set_attribute')
+            ->willReturnCallback(function (string $key, string $value) use ($tagMatcher) {
+                switch ($tagMatcher->getInvocationCount()) {
+                    case 1:
+                        $this->assertEquals('data-stellarwp-namespace-notice-id', $key);
+                        break;
+                    case 2:
+                        $this->assertEquals('data-stellarwp-namespace-location', $key);
+                        $this->assertEquals('below_header', $value);
+                        break;
+                }
+            });
+
+        $tagProcessorMock
+            ->expects($this->once())
+            ->method('next_tag');
+
+        $tagProcessorMock
+            ->expects($this->once())
+            ->method('__toString')
+            ->willReturn($expectedNoticeWithAttributes);
+
+        $this->setClassMock('WP_HTML_Tag_Processor', $tagProcessorMock);
+
+        $this->assertEquals($expectedNoticeWithAttributes, $renderAdminNotice($notice));
+    }
+
+    public function testShouldOmitLocationForCustomInPlaceNotices(): void
+    {
+        $notice = (new AdminNotice('test_id', function () {
+            return '<div>It is Stellar at StellarWP</div>';
+        }))
+            ->custom()
+            ->inPlace();
+
+        $expectedNoticeWithAttributes = "<div data-stellarwp-namespace-notice-id='test_id' data-stellarwp-namespace-location='below_header'>It is Stellar at StellarWP</div>";
+
+        $renderAdminNotice = new RenderAdminNotice('namespace');
+
+        $tagProcessorMock = $this->createMock(TagProcessorMock::class);
+
+        $tagProcessorMock
+            ->expects($this->once())
+            ->method('set_attribute')
+            ->with('data-stellarwp-namespace-notice-id');
+
+        $tagProcessorMock
+            ->expects($this->once())
+            ->method('next_tag');
+
+        $tagProcessorMock
+            ->expects($this->once())
+            ->method('__toString')
+            ->willReturn($expectedNoticeWithAttributes);
+
+        $this->setClassMock('WP_HTML_Tag_Processor', $tagProcessorMock);
+
+        $this->assertEquals($expectedNoticeWithAttributes, $renderAdminNotice($notice));
+    }
+}
+
+class TagProcessorMock
+{
+    public function __construct($content)
+    {
+        $this->content = $content;
+    }
+
+    public function next_tag(): self
+    {
+        return $this;
+    }
+
+    public function set_attribute($name, $value) {}
+
+    public function __toString()
+    {
+        return '';
     }
 }

--- a/tests/unit/Actions/RenderAdminNoticeTest.php
+++ b/tests/unit/Actions/RenderAdminNoticeTest.php
@@ -14,12 +14,14 @@ class RenderAdminNoticeTest extends TestCase
     public function testShouldRenderNoticeWithoutWrapper(): void
     {
         $notice = (new AdminNotice('test_id', 'Hello world!'))
-            ->withoutAutoParagraph()
-            ->withoutWrapper();
+            ->withoutAutoParagraph();
 
         $renderAdminNotice = new RenderAdminNotice('namespace');
 
-        $this->assertEquals('Hello world!', $renderAdminNotice($notice));
+        $this->assertEquals(
+            '<div class=\'notice notice-info\' data-stellarwp-namespace-notice-id=\'test_id\'>Hello world!</div>',
+            $renderAdminNotice($notice)
+        );
     }
 
     /**

--- a/tests/unit/AdminNoticeTest.php
+++ b/tests/unit/AdminNoticeTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use StellarWP\AdminNotices\AdminNotice;
 use StellarWP\AdminNotices\Tests\Support\Helper\TestCase;
+use StellarWP\AdminNotices\ValueObjects\NoticeLocation;
 use StellarWP\AdminNotices\ValueObjects\NoticeUrgency;
 use StellarWP\AdminNotices\ValueObjects\ScreenCondition;
 use StellarWP\AdminNotices\ValueObjects\UserCapability;
@@ -389,6 +390,48 @@ class AdminNoticeTest extends TestCase
         // standardStyles is an alias for alternateStyles(false)
         $self = $notice->standardStyles();
         $this->assertFalse($notice->usesAlternateStyles());
+        $this->assertSame($notice, $self);
+    }
+
+    /**
+     * @covers ::custom
+     * @covers ::isCustom
+     *
+     * @unreleased
+     */
+    public function testCustom(): void
+    {
+        $notice = new AdminNotice('test_id', 'test');
+
+        // Defaults to false
+        $this->assertFalse($notice->isCustom());
+
+        // Method can be set to true
+        $self = $notice->custom();
+        $this->assertTrue($notice->isCustom());
+        $this->assertSame($notice, $self);
+
+        // Method can be explicitly set to false
+        $notice->custom(false);
+        $this->assertFalse($notice->isCustom());
+    }
+
+    /**
+     * @covers ::location
+     * @covers ::getLocation
+     *
+     * @unreleased
+     */
+    public function testLocation(): void
+    {
+        $notice = new AdminNotice('test_id', 'test');
+
+        // Defaults to standard
+        $this->assertTrue($notice->getLocation()->isStandard());
+
+        // Returns the location
+        $self = $notice->location(NoticeLocation::inline());
+        $this->assertTrue($notice->getLocation()->isInline());
         $this->assertSame($notice, $self);
     }
 }

--- a/tests/unit/AdminNoticeTest.php
+++ b/tests/unit/AdminNoticeTest.php
@@ -219,64 +219,6 @@ class AdminNoticeTest extends TestCase
     }
 
     /**
-     * @covers ::withWrapper
-     * @covers ::withoutWrapper
-     * @covers ::usesWrapper
-     */
-    public function testWithWrapper(): void
-    {
-        // Defaults to true
-        $notice = new AdminNotice('test_id', 'test');
-        $this->assertTrue($notice->usesWrapper());
-
-        // Method can be set to false
-        $self = $notice->withWrapper(false);
-        $this->assertFalse($notice->usesWrapper());
-        $this->assertSame($notice, $self);
-
-        // Method can be explicitly set to true
-        $notice->withWrapper(true);
-        $this->assertTrue($notice->usesWrapper());
-
-        // withoutWrapper is an alias for withWrapper(false)
-        $self = $notice->withoutWrapper();
-        $this->assertFalse($notice->usesWrapper());
-        $this->assertSame($notice, $self);
-    }
-
-    /**
-     * @covers ::inline
-     * @covers ::notInline
-     * @covers ::isInline
-     *
-     * @since 1.2.0
-     */
-    public function testInline(): void
-    {
-        // Defaults to false
-        $notice = new AdminNotice('test_id', 'test');
-        $this->assertFalse($notice->isInline());
-
-        // Method defaults to true
-        $self = $notice->inline();
-        $this->assertTrue($notice->isInline());
-        $this->assertSame($notice, $self);
-
-        // Method can be explicitly set to false
-        $notice->inline(false);
-        $this->assertFalse($notice->isInline());
-
-        // Method can be set to true
-        $notice->inline(true);
-        $this->assertTrue($notice->isInline());
-
-        // notInline is an alias for inline(false)
-        $self = $notice->notInline();
-        $this->assertFalse($notice->isInline());
-        $this->assertSame($notice, $self);
-    }
-
-    /**
      * @covers ::dismissible
      * @covers ::notDismissible
      * @covers ::isDismissible

--- a/tests/unit/ValueObjects/NoticeLocationTest.php
+++ b/tests/unit/ValueObjects/NoticeLocationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace StellarWP\AdminNotices\Tests\Unit\ValueObjects;
+
+use InvalidArgumentException;
+use StellarWP\AdminNotices\Tests\Support\Helper\TestCase;
+use StellarWP\AdminNotices\ValueObjects\NoticeLocation;
+
+/**
+ * @coversDefaultClass \StellarWP\AdminNotices\ValueObjects\NoticeLocation
+ */
+class NoticeLocationTest extends TestCase
+{
+    /**
+     * @covers ::aboveHeader
+     *
+     * @unreleased
+     */
+    public function testAboveHeader(): void
+    {
+        $location = NoticeLocation::aboveHeader();
+
+        $this->assertEquals('above_header', $location);
+    }
+
+    /**
+     * @covers ::standard
+     *
+     * @unreleased
+     */
+    public function testStandard(): void
+    {
+        $location = NoticeLocation::standard();
+
+        $this->assertEquals('below_header', $location);
+    }
+
+    /**
+     * @covers ::belowHeader
+     *
+     * @unreleased
+     */
+    public function testBelowHeader(): void
+    {
+        $location = NoticeLocation::belowHeader();
+
+        $this->assertEquals('below_header', $location);
+    }
+
+    /**
+     * @covers ::inline
+     *
+     * @unreleased
+     */
+    public function testInline(): void
+    {
+        $location = NoticeLocation::inline();
+
+        $this->assertEquals('inline', $location);
+    }
+
+    /**
+     * @covers ::__toString
+     *
+     * @unreleased
+     */
+    public function testToString(): void
+    {
+        $location = new NoticeLocation('above_header');
+
+        $this->assertSame('above_header', (string)$location);
+    }
+
+    /**
+     * @dataProvider constructorValidationDataProvider
+     * @covers ::__construct
+     */
+    public function testConstructorValidation($value, $shouldPass): void
+    {
+        if ($shouldPass) {
+            $this->assertInstanceOf(NoticeLocation::class, new NoticeLocation($value));
+        } else {
+            $this->expectException(InvalidArgumentException::class);
+            new NoticeLocation($value);
+        }
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public function constructorValidationDataProvider(): array
+    {
+        return [
+            'above header is valid' => ['above_header', true],
+            'below header is valid' => ['below_header', true],
+            'inline is valid' => ['inline', true],
+            'standard is invalid' => ['standard', false],
+            'empty string is invalid' => ['', false],
+        ];
+    }
+}


### PR DESCRIPTION
Resolves #4

## Description
This PR is a fairly significant rebuild of how custom notices work. A fundamentally different approach was taken than before, which used the confusing concept of "wrappers". It also had the problem that, when trying to position a custom notice, you still ended up fighting with the standard notice styling.

As described in the related Issue, a new approach was taken for custom notices. Namely, the `$notice->custom()` method. All "wrapper" methods and such are dropped. Standard notices just do their thing, and custom notices use the `custom()` method. This completely changes how custom notices are rendered and handled.

When a custom notice is rendered, it applies the notice attribute and the notice location attribute to the outer custom notice HTML. The ID is used to identify the notice, and the location is used to move the notice to where it should go. Presently, the standard locations are supported, and the JS was updated to handle this — as WP is no longer handling it, due to styling issues.

Next, I added a new `NoticeElementProperties` DTO. This object's sole purpose is to make adding the rather crazy attribute names easy. The notice and properties object is now passed to the render callback, for easy use.

Finally, applying `$elementProperties->customCloserAttributes()` attributes to any node will cause that node to close the notification. Note that the closer doesn't actually have to be inside the notice — and can be anywhere.

For more information on these new methods, please refer to the README changes in the files changes.

## Next Ideas
I had #6 in mind big time while building this. I believe the new DTO will really help with custom templates, as they'll effectively work closely to how the render callback works in this PR.

It also occurred to me, while making this, that it would be handy to have a way of enqueueing CSS or JS as part of a notice. That way the files are only actually loaded on the page if the notice passes all the visibility conditions.

## Release Thoughts
This is technically backwards-breaking, but only for custom notices. I'm thinking this may merit a 2.0 release, but given how  new and barely used this is, I'm tempted to do it as a minor release.