### PR TITLE
Fix: require WP_Screen if missing

### DIFF
--- a/src/ValueObjects/ScreenCondition.php
+++ b/src/ValueObjects/ScreenCondition.php
@@ -49,6 +49,10 @@ class ScreenCondition
         static $wpScreenProperties = null;
 
         if ($wpScreenProperties === null) {
+            if (! class_exists('WP_Screen')) {
+                require_once ABSPATH . 'wp-admin/includes/screen.php';
+            }
+
             $wpScreenProperties = get_class_vars('WP_Screen');
         }
 

--- a/src/ValueObjects/ScreenCondition.php
+++ b/src/ValueObjects/ScreenCondition.php
@@ -50,7 +50,7 @@ class ScreenCondition
 
         if ($wpScreenProperties === null) {
             if (! class_exists('WP_Screen')) {
-                require_once ABSPATH . 'wp-admin/includes/screen.php';
+                require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
             }
 
             $wpScreenProperties = get_class_vars('WP_Screen');


### PR DESCRIPTION
Resolves: #12

This adds the missing WP_Screen class when not found.