### PR TITLE
Fix: Render notices after page actions if present

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -31,7 +31,7 @@ jobs:
                 id: get-composer-cache-dir
                 run: |
                     echo "::set-output name=dir::$(composer config cache-files-dir)"
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v4
                 id: composer-cache
                 with:
                     path: ${{ steps.get-composer-cache-dir.outputs.dir }}

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -68,7 +68,12 @@
         const location = $notice.data(locationAttribute);
 
         if (location === 'below_header') {
+        const $pageTitleAction = $('a.page-title-action');
+        if ($pageTitleAction.length) {
+            $notice.insertAfter($pageTitleAction);
+        } else {
             $notice.insertAfter('h1');
+        }
         } else if (location === 'above_header') {
             $notice.insertBefore('h1');
         } else if (location === 'inline') {

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -68,6 +68,7 @@
         const location = $notice.data(locationAttribute);
 
         if (location === 'below_header') {
+        // Place after the page action element (e.g., "Add Plugin" on Plugins page) if it exists, otherwise after <h1>.
         const $pageTitleAction = $('a.page-title-action');
         if ($pageTitleAction.length) {
             $notice.insertAfter($pageTitleAction);

--- a/src/resources/admin-notices.js
+++ b/src/resources/admin-notices.js
@@ -68,7 +68,9 @@
         const location = $notice.data(locationAttribute);
 
         if (location === 'below_header') {
-        // Place after the page action element (e.g., "Add Plugin" on Plugins page) if it exists, otherwise after <h1>.
+        // Place notice after the page action element (e.g., "Add Plugin" on the Plugins page) if it exists; 
+        // otherwise, insert it after the <h1>. On some pages, placing the notice directly after the <h1> 
+        // can cause it to appear between the header and its action button, leading to layout issues.
         const $pageTitleAction = $('a.page-title-action');
         if ($pageTitleAction.length) {
             $notice.insertAfter($pageTitleAction);


### PR DESCRIPTION
## Description
On certain admin pages, such as the Plugins page, there is a page action link (e.g., "Add Plugin") displayed immediately after the H1 header. Currently, notices with the `below_header` location are rendered directly after the H1 tag, which places them between the header and the page action. This can lead to an inconsistent and visually confusing user interface.

This PR introduces a conditional check for the presence of a page title action element. If the element exists, notices with the location set to `below_header` will be rendered immediately after the page action instead of directly after the H1, ensuring a more consistent and intuitive layout.

Also updates the GitHub Actions workflow to use actions/cache@v4 instead of the deprecated v2 version. This change resolves the deprecation error in the unit tests.

## Affects
Admin notices rendered with `below_header` on pages with `page-title-action` links.

## Visuals

### Issue
<img width="1891" alt="Screenshot 2025-07-09 at 8 58 04 PM" src="https://github.com/user-attachments/assets/eac7bca0-3e01-46d1-9ba4-90452936651f" />

### Resolved
<img width="1893" alt="Screenshot 2025-07-09 at 9 06 49 PM" src="https://github.com/user-attachments/assets/83b9049e-b49c-4f45-9ebe-35c4c2d7d800" />

## Testing Instructions
- Render a notice on the plugins page.
- Set the location to `below_header`.
- Verify the notice renders after the "Add Plugins" link.
- Verify the notice renders properly after the H1 on any other admin page.
